### PR TITLE
Fixed issues with csv methods since Yahoo doesn't support them 

### DIFF
--- a/src/Helpers/CapitalGainHelper.cs
+++ b/src/Helpers/CapitalGainHelper.cs
@@ -6,6 +6,15 @@ internal class CapitalGainHelper : YahooJsonBase
 {
     internal override IEnumerable<T> ParseYahooJsonData<T>(string jsonData)
     {
-        throw new NotImplementedException();
+        var capitalGain = JsonConvert.DeserializeObject<CapitalGainDataRoot>(jsonData);
+
+        if (capitalGain != null && capitalGain.Chart?.Result != null)
+        {
+            var result = capitalGain.Chart.Result.Cast<T>();
+
+            return result;
+        }
+
+        return [];
     }
 }

--- a/src/Helpers/CapitalGainHelper.cs
+++ b/src/Helpers/CapitalGainHelper.cs
@@ -1,32 +1,11 @@
-﻿namespace OoplesFinance.YahooFinanceAPI.Helpers;
+﻿
 
-internal class CapitalGainHelper : YahooCsvBase
+namespace OoplesFinance.YahooFinanceAPI.Helpers;
+
+internal class CapitalGainHelper : YahooJsonBase
 {
-    /// <summary>
-    /// Parses the raw csv data for the Capital Gain Data
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="csvData"></param>
-    /// <returns>Returns a IEnumerable<CapitalGainHelper> using the given csvData</returns>
-    internal override IEnumerable<T> ParseYahooCsvData<T>(IEnumerable<string[]> csvData)
+    internal override IEnumerable<T> ParseYahooJsonData<T>(string jsonData)
     {
-        var parsedDataList = csvData.Select(csvRow =>
-        {
-            // Perform a try parse for all columns per row
-            var dateSuccess = DateTime.TryParse(csvRow[0], CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedDate);
-            var capitalGainSuccess = double.TryParse(csvRow[1], NumberStyles.Number | NumberStyles.AllowDecimalPoint | NumberStyles.Float,
-                CultureInfo.InvariantCulture, out var parsedCapitalGain);
-
-            // Add either the parsed value or the default if there was a parsing error
-            CapitalGainData capitalGainData = new()
-            {
-                Date = dateSuccess ? parsedDate : default,
-                CapitalGain = capitalGainSuccess ? parsedCapitalGain : default
-            };
-
-            return capitalGainData;
-        });
-
-        return (IEnumerable<T>)parsedDataList;
+        throw new NotImplementedException();
     }
 }

--- a/src/Helpers/ChartHelper.cs
+++ b/src/Helpers/ChartHelper.cs
@@ -14,11 +14,11 @@ internal class ChartHelper : YahooJsonBase
         var result = new ChartInfo
         {
             DateList = new List<DateTime>(root != null ? root.Timestamp.Select(x => x.FromUnixTimeStamp()) : []),
-            CloseList = new List<double>(root != null ? root.Indicators.Quote.SelectMany(x => x.Close.Select(y => y.GetValueOrDefault())) : []),
-            OpenList = new List<double>(root != null ? root.Indicators.Quote.SelectMany(x => x.Open.Select(y => y.GetValueOrDefault())) : []),
-            HighList = new List<double>(root != null ? root.Indicators.Quote.SelectMany(x => x.High.Select(y => y.GetValueOrDefault())) : []),
-            VolumeList = new List<double>(root != null ? root.Indicators.Quote.SelectMany(x => x.Volume.Select(y => y.GetValueOrDefault())) : []),
-            LowList = new List<double>(root != null ? root.Indicators.Quote.SelectMany(x => x.Low.Select(y => y.GetValueOrDefault())) : [])
+            CloseList = new List<double>(root != null ? root.Indicators?.Quote.SelectMany(x => x.Close.Select(y => y.GetValueOrDefault())) ?? [] : []),
+            OpenList = new List<double>(root != null ? root.Indicators?.Quote.SelectMany(x => x.Open.Select(y => y.GetValueOrDefault())) ?? [] : []),
+            HighList = new List<double>(root != null ? root.Indicators?.Quote.SelectMany(x => x.High.Select(y => y.GetValueOrDefault())) ?? [] : []),
+            VolumeList = new List<double>(root != null ? root.Indicators?.Quote.SelectMany(x => x.Volume.Select(y => (double)y.GetValueOrDefault())) ?? [] : []),
+            LowList = new List<double>(root != null ? root.Indicators?.Quote.SelectMany(x => x.Low.Select(y => y.GetValueOrDefault())) ?? [] : [])
         };
 
         if (result.DateList.Count == 0 || result.CloseList.Count == 0 || result.OpenList.Count == 0 || result.HighList.Count == 0 || 

--- a/src/Helpers/DividendHelper.cs
+++ b/src/Helpers/DividendHelper.cs
@@ -9,9 +9,9 @@ internal class DividendHelper : YahooJsonBase
 
         if (dividendData != null && dividendData.Chart?.Result != null)
         {
-            var quotes = dividendData.Chart.Result.Cast<T>();
+            var results = dividendData.Chart.Result.Cast<T>();
 
-            return quotes;
+            return results;
         }
 
         return [];

--- a/src/Helpers/DividendHelper.cs
+++ b/src/Helpers/DividendHelper.cs
@@ -5,6 +5,15 @@ internal class DividendHelper : YahooJsonBase
 {
     internal override IEnumerable<T> ParseYahooJsonData<T>(string jsonData)
     {
-        throw new NotImplementedException();
+        var dividendData = JsonConvert.DeserializeObject<DividendRoot>(jsonData);
+
+        if (dividendData != null && dividendData.Chart?.Result != null)
+        {
+            var quotes = dividendData.Chart.Result.Cast<T>();
+
+            return quotes;
+        }
+
+        return [];
     }
 }

--- a/src/Helpers/DividendHelper.cs
+++ b/src/Helpers/DividendHelper.cs
@@ -1,32 +1,10 @@
-﻿namespace OoplesFinance.YahooFinanceAPI.Helpers;
+﻿
+namespace OoplesFinance.YahooFinanceAPI.Helpers;
 
-internal class DividendHelper : YahooCsvBase
+internal class DividendHelper : YahooJsonBase
 {
-    /// <summary>
-    /// Parses the raw csv data for the Dividend Data
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="csvData"></param>
-    /// <returns>Returns a IEnumerable<DividendData> using the given csvData</returns>
-    internal override IEnumerable<T> ParseYahooCsvData<T>(IEnumerable<string[]> csvData)
+    internal override IEnumerable<T> ParseYahooJsonData<T>(string jsonData)
     {
-        var parsedDataList = csvData.Select(csvRow => 
-        {
-            // Perform a try parse for all columns per row
-            var dateSuccess = DateTime.TryParse(csvRow[0], CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedDate);
-            var dividendSuccess = double.TryParse(csvRow[1], NumberStyles.AllowDecimalPoint | NumberStyles.Float | NumberStyles.Number,
-                CultureInfo.InvariantCulture, out var parsedDividend);
-
-            // Add either the parsed value or the default if there was a parsing error
-            DividendData dividendData = new()
-            {
-                Date = dateSuccess ? parsedDate : default,
-                Dividend = dividendSuccess ? parsedDividend : default
-            };
-
-            return dividendData;
-        });
-
-        return (IEnumerable<T>)parsedDataList;
+        throw new NotImplementedException();
     }
 }

--- a/src/Helpers/DownloadHelper.cs
+++ b/src/Helpers/DownloadHelper.cs
@@ -13,7 +13,7 @@ internal static class DownloadHelper
     /// <param name="includeAdjustedClose"></param>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
-    internal static async Task<IEnumerable<string[]>> DownloadRawCsvDataAsync(string symbol, DataType dataType, DataFrequency dataFrequency,
+    internal static async Task<string> DownloadRawCsvDataAsync(string symbol, DataType dataType, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate, bool includeAdjustedClose)
     {
         if (string.IsNullOrWhiteSpace(symbol))
@@ -22,15 +22,8 @@ internal static class DownloadHelper
         }
         else
         {
-            var rawData = await DownloadRawDataAsync(BuildYahooCsvUrl(symbol, dataType, dataFrequency, startDate, endDate, includeAdjustedClose));
-
-            if (!string.IsNullOrWhiteSpace(rawData))
-            {
-                return GetBaseCsvData(rawData);
-            }
+            return await DownloadRawDataAsync(BuildYahooCsvUrl(symbol, dataType, dataFrequency, startDate, endDate, includeAdjustedClose));
         }
-
-        return [];
     }
 
     /// <summary>

--- a/src/Helpers/HistoricalHelper.cs
+++ b/src/Helpers/HistoricalHelper.cs
@@ -15,9 +15,9 @@ internal class HistoricalHelper : YahooJsonBase
 
         if (historicalData != null && historicalData.Chart?.Result != null)
         {
-            var quotes = historicalData.Chart.Result.SelectMany(x => x.Indicators.Quote).Cast<T>();
+            var result = historicalData.Chart.Result.Cast<T>();
 
-            return quotes;
+            return result;
         }
 
         return [];

--- a/src/Helpers/HistoricalHelper.cs
+++ b/src/Helpers/HistoricalHelper.cs
@@ -13,6 +13,13 @@ internal class HistoricalHelper : YahooJsonBase
     {
         var historicalData = JsonConvert.DeserializeObject<HistoricalDataRoot>(jsonData);
 
-        return historicalData != null ? (IEnumerable<T>)(historicalData?.Chart?.Result.Select(x => x.Indicators.Quote) ?? []) : [];
+        if (historicalData != null && historicalData.Chart?.Result != null)
+        {
+            var quotes = historicalData.Chart.Result.SelectMany(x => x.Indicators.Quote).Cast<T>();
+
+            return quotes;
+        }
+
+        return [];
     }
 }

--- a/src/Helpers/HistoricalHelper.cs
+++ b/src/Helpers/HistoricalHelper.cs
@@ -13,6 +13,6 @@ internal class HistoricalHelper : YahooJsonBase
     {
         var historicalData = JsonConvert.DeserializeObject<HistoricalDataRoot>(jsonData);
 
-        return historicalData != null ? (IEnumerable<T>)historicalData.Chart.Result.Select(x => x.Indicators.Quote) : [];
+        return historicalData != null ? (IEnumerable<T>)(historicalData?.Chart?.Result.Select(x => x.Indicators.Quote) ?? []) : [];
     }
 }

--- a/src/Helpers/HistoricalHelper.cs
+++ b/src/Helpers/HistoricalHelper.cs
@@ -1,47 +1,18 @@
-﻿namespace OoplesFinance.YahooFinanceAPI.Helpers;
+﻿
+namespace OoplesFinance.YahooFinanceAPI.Helpers;
 
-internal class HistoricalHelper : YahooCsvBase
+internal class HistoricalHelper : YahooJsonBase
 {
     /// <summary>
-    /// Parses the raw csv data for the Historical Data
+    /// Parses the raw json data for the Financial Data
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    /// <param name="csvData"></param>
-    /// <returns>Returns a IEnumerable<HistoricalData> using the given csvData</returns>
-    internal override IEnumerable<T> ParseYahooCsvData<T>(IEnumerable<string[]> csvData)
+    /// <param name="jsonData"></param>
+    /// <returns></returns>
+    internal override IEnumerable<T> ParseYahooJsonData<T>(string jsonData)
     {
-        var parsedDataList = csvData.Select(csvRow =>
-        {
-            // Perform a try parse for all columns per row
-            var dateSuccess = DateTime.TryParse(csvRow[0], CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedDate);
-            var openSuccess = double.TryParse(csvRow[1], NumberStyles.AllowDecimalPoint | NumberStyles.Float | NumberStyles.Number,
-                CultureInfo.InvariantCulture, out var parsedOpen);
-            var highSuccess = double.TryParse(csvRow[2], NumberStyles.AllowDecimalPoint | NumberStyles.Float | NumberStyles.Number,
-                CultureInfo.InvariantCulture, out var parsedHigh);
-            var lowSuccess = double.TryParse(csvRow[3], NumberStyles.AllowDecimalPoint | NumberStyles.Float | NumberStyles.Number,
-                CultureInfo.InvariantCulture, out var parsedLow);
-            var closeSuccess = double.TryParse(csvRow[4], NumberStyles.AllowDecimalPoint | NumberStyles.Float | NumberStyles.Number,
-                CultureInfo.InvariantCulture, out var parsedClose);
-            var adjCloseSuccess = double.TryParse(csvRow[5], NumberStyles.AllowDecimalPoint | NumberStyles.Float | NumberStyles.Number,
-                CultureInfo.InvariantCulture, out var parsedAdjClose);
-            var volumeSuccess = double.TryParse(csvRow[6], NumberStyles.Integer | NumberStyles.Number,
-                CultureInfo.InvariantCulture, out var parsedVolume);
+        var historicalData = JsonConvert.DeserializeObject<HistoricalDataRoot>(jsonData);
 
-            // Add either the parsed value or the default if there was a parsing error
-            HistoricalData historicalData = new()
-            {
-                Date = dateSuccess ? parsedDate : default,
-                Open = openSuccess ? parsedOpen : default,
-                High = highSuccess ? parsedHigh : default,
-                Low = lowSuccess ? parsedLow : default,
-                Close = closeSuccess ? parsedClose : default,
-                AdjClose = adjCloseSuccess ? parsedAdjClose : default,
-                Volume = volumeSuccess ? parsedVolume : default
-            };
-
-            return historicalData;
-        });
-
-        return (IEnumerable<T>)parsedDataList;
+        return historicalData != null ? (IEnumerable<T>)historicalData.Chart.Result.Select(x => x.Indicators.Quote) : [];
     }
 }

--- a/src/Helpers/StockSplitHelper.cs
+++ b/src/Helpers/StockSplitHelper.cs
@@ -1,30 +1,10 @@
-﻿namespace OoplesFinance.YahooFinanceAPI.Helpers;
+﻿
+namespace OoplesFinance.YahooFinanceAPI.Helpers;
 
-internal class StockSplitHelper : YahooCsvBase
+internal class StockSplitHelper : YahooJsonBase
 {
-    /// <summary>
-    /// Parses the raw csv data for the Stock Split Data
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="csvData"></param>
-    /// <returns>Returns a IEnumerable<StockSplitData> using the given csvData</returns>
-    internal override IEnumerable<T> ParseYahooCsvData<T>(IEnumerable<string[]> csvData)
+    internal override IEnumerable<T> ParseYahooJsonData<T>(string jsonData)
     {
-        var parsedDataList = csvData.Select(csvRow =>
-        {
-            // Perform a try parse for all columns per row
-            var dateSuccess = DateTime.TryParse(csvRow[0], CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedDate);
-
-            // Add either the parsed value or the default if there was a parsing error
-            StockSplitData stockSplitData = new()
-            {
-                Date = dateSuccess ? parsedDate : default,
-                StockSplit = csvRow.Length > 1 ? csvRow[1] : string.Empty
-            };
-
-            return stockSplitData;
-        });
-
-        return (IEnumerable<T>)parsedDataList;
+        throw new NotImplementedException();
     }
 }

--- a/src/Helpers/StockSplitHelper.cs
+++ b/src/Helpers/StockSplitHelper.cs
@@ -5,6 +5,15 @@ internal class StockSplitHelper : YahooJsonBase
 {
     internal override IEnumerable<T> ParseYahooJsonData<T>(string jsonData)
     {
-        throw new NotImplementedException();
+        var stockSplitData = JsonConvert.DeserializeObject<StockSplitRoot>(jsonData);
+
+        if (stockSplitData != null && stockSplitData.Chart?.Result != null)
+        {
+            var results = stockSplitData.Chart.Result.Cast<T>();
+
+            return results;
+        }
+
+        return [];
     }
 }

--- a/src/Helpers/UrlHelper.cs
+++ b/src/Helpers/UrlHelper.cs
@@ -14,7 +14,7 @@ internal static class UrlHelper
     /// <param name="includeAdjClose"></param>
     /// <returns></returns>
     internal static string BuildYahooCsvUrl(string symbol, DataType dataType, DataFrequency dataFrequency, DateTime startDate, DateTime? endDate, bool includeAdjClose) => 
-        string.Format(CultureInfo.InvariantCulture, $"https://query2.finance.yahoo.com/v7/finance/download/{symbol}?period1={startDate.ToUnixTimestamp()}" +
+        string.Format(CultureInfo.InvariantCulture, $"https://query2.finance.yahoo.com/v8/finance/download/{symbol}?period1={startDate.ToUnixTimestamp()}" +
             $"&period2={(endDate ?? DateTime.Now).ToUnixTimestamp()}&interval={GetFrequencyString(dataFrequency)}&events={GetEventsString(dataType)}" +
             $"&includeAdjustedClose={includeAdjClose}");
 

--- a/src/Helpers/UrlHelper.cs
+++ b/src/Helpers/UrlHelper.cs
@@ -14,7 +14,7 @@ internal static class UrlHelper
     /// <param name="includeAdjClose"></param>
     /// <returns></returns>
     internal static string BuildYahooCsvUrl(string symbol, DataType dataType, DataFrequency dataFrequency, DateTime startDate, DateTime? endDate, bool includeAdjClose) => 
-        string.Format(CultureInfo.InvariantCulture, $"https://query2.finance.yahoo.com/v8/finance/download/{symbol}?period1={startDate.ToUnixTimestamp()}" +
+        string.Format(CultureInfo.InvariantCulture, $"https://query2.finance.yahoo.com/v8/finance/chart/{symbol}?period1={startDate.ToUnixTimestamp()}" +
             $"&period2={(endDate ?? DateTime.Now).ToUnixTimestamp()}&interval={GetFrequencyString(dataFrequency)}&events={GetEventsString(dataType)}" +
             $"&includeAdjustedClose={includeAdjClose}");
 

--- a/src/Models/CapitalGainData.cs
+++ b/src/Models/CapitalGainData.cs
@@ -1,9 +1,8 @@
 ﻿namespace OoplesFinance.YahooFinanceAPI.Models;
 
 [Serializable]
-public class CapitalGainData
+public class CapitalGainDataRoot
 {
-    public DateTime Date { get; set; }
-
-    public double CapitalGain { get; set; }
+    [JsonProperty("chart")]
+    public Chart? Chart { get; set; }
 }

--- a/src/Models/ChartData.cs
+++ b/src/Models/ChartData.cs
@@ -9,87 +9,6 @@ public class ChartData
     public object Error { get; set; } = new();
 }
 
-public class CurrentTradingPeriod
-{
-    [JsonProperty("pre")]
-    public TradingPeriod Pre { get; set; } = new();
-
-    [JsonProperty("regular")]
-    public TradingPeriod Regular { get; set; } = new();
-
-    [JsonProperty("post")]
-    public TradingPeriod Post { get; set; } = new();
-}
-
-public class Indicators
-{
-    [JsonProperty("quote")]
-    public List<HistoricalDataQuote> Quote { get; set; } = [];
-}
-
-public class Meta
-{
-    [JsonProperty("currency")]
-    public string Currency { get; set; } = string.Empty;
-
-    [JsonProperty("symbol")]
-    public string Symbol { get; set; } = string.Empty;
-
-    [JsonProperty("exchangeName")]
-    public string ExchangeName { get; set; } = string.Empty;
-
-    [JsonProperty("instrumentType")]
-    public string InstrumentType { get; set; } = string.Empty;
-
-    [JsonProperty("firstTradeDate")]
-    public int? FirstTradeDate { get; set; }
-
-    [JsonProperty("regularMarketTime")]
-    public int? RegularMarketTime { get; set; }
-
-    [JsonProperty("hasPrePostMarketData")]
-    public bool? HasPrePostMarketData { get; set; }
-
-    [JsonProperty("gmtoffset")]
-    public int? Gmtoffset { get; set; }
-
-    [JsonProperty("timezone")]
-    public string Timezone { get; set; } = string.Empty;
-
-    [JsonProperty("exchangeTimezoneName")]
-    public string ExchangeTimezoneName { get; set; } = string.Empty;
-
-    [JsonProperty("regularMarketPrice")]
-    public double? RegularMarketPrice { get; set; }
-
-    [JsonProperty("chartPreviousClose")]
-    public double? ChartPreviousClose { get; set; }
-
-    [JsonProperty("previousClose")]
-    public double? PreviousClose { get; set; }
-
-    [JsonProperty("scale")]
-    public int? Scale { get; set; }
-
-    [JsonProperty("priceHint")]
-    public int? PriceHint { get; set; }
-
-    [JsonProperty("currentTradingPeriod")]
-    public CurrentTradingPeriod CurrentTradingPeriod { get; set; } = new();
-
-    [JsonProperty("tradingPeriods")]
-    public List<List<TradingPeriod>> TradingPeriods { get; set; } = [];
-
-    [JsonProperty("dataGranularity")]
-    public string DataGranularity { get; set; } = string.Empty;
-
-    [JsonProperty("range")]
-    public string Range { get; set; } = string.Empty;
-
-    [JsonProperty("validRanges")]
-    public List<string> ValidRanges { get; set; } = [];
-}
-
 public class TradingPeriod
 {
     [JsonProperty("timezone")]
@@ -105,34 +24,16 @@ public class TradingPeriod
     public int? Gmtoffset { get; set; }
 }
 
-public class Quote
-{
-    [JsonProperty("open")]
-    public List<double?> Open { get; set; } = [];
-
-    [JsonProperty("low")]
-    public List<double?> Low { get; set; } = [];
-
-    [JsonProperty("volume")]
-    public List<double?> Volume { get; set; } = [];
-
-    [JsonProperty("close")]
-    public List<double?> Close { get; set; } = [];
-
-    [JsonProperty("high")]
-    public List<double?> High { get; set; } = [];
-}
-
 public class ChartResult
 {
     [JsonProperty("meta")]
-    public Meta Meta { get; set; } = new();
+    public Meta? Meta { get; set; }
 
     [JsonProperty("timestamp")]
     public List<long> Timestamp { get; set; } = [];
 
     [JsonProperty("indicators")]
-    public Indicators Indicators { get; set; } = new();
+    public Indicators? Indicators { get; set; }
 }
 
 public class ChartRoot

--- a/src/Models/ChartData.cs
+++ b/src/Models/ChartData.cs
@@ -24,7 +24,7 @@ public class CurrentTradingPeriod
 public class Indicators
 {
     [JsonProperty("quote")]
-    public List<ChartQuote> Quote { get; set; } = [];
+    public List<HistoricalDataQuote> Quote { get; set; } = [];
 }
 
 public class Meta
@@ -105,7 +105,7 @@ public class TradingPeriod
     public int? Gmtoffset { get; set; }
 }
 
-public class ChartQuote
+public class Quote
 {
     [JsonProperty("open")]
     public List<double?> Open { get; set; } = [];

--- a/src/Models/DividendData.cs
+++ b/src/Models/DividendData.cs
@@ -1,9 +1,103 @@
 ﻿namespace OoplesFinance.YahooFinanceAPI.Models;
 
 [Serializable]
-public class DividendData
-{
-    public DateTime Date { get; set; }
+public record DividendData(
+    [property: JsonProperty("amount", NullValueHandling = NullValueHandling.Ignore)] double? Amount,
+    [property: JsonProperty("date", NullValueHandling = NullValueHandling.Ignore)] int? Date
+);
 
-    public double Dividend { get; set; }
-}
+public record AdjClose(
+    [property: JsonProperty("adjclose", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<double?> Adjclose
+);
+
+public record Chart(
+    [property: JsonProperty("result", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<Result> Result,
+    [property: JsonProperty("error", NullValueHandling = NullValueHandling.Ignore)] object Error
+);
+
+public record CurrentTradingPeriod(
+    [property: JsonProperty("pre", NullValueHandling = NullValueHandling.Ignore)] Pre Pre,
+    [property: JsonProperty("regular", NullValueHandling = NullValueHandling.Ignore)] Regular Regular,
+    [property: JsonProperty("post", NullValueHandling = NullValueHandling.Ignore)] Post Post
+);
+
+public record Dividends(
+    [property: JsonProperty("dividends", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<DividendData> DividendsList
+);
+
+public record Events(
+    [property: JsonProperty("dividends", NullValueHandling = NullValueHandling.Ignore)] Dividends Dividends
+);
+
+public record Indicators(
+    [property: JsonProperty("quote", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<Quote> Quote,
+    [property: JsonProperty("adjclose", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<AdjClose> Adjclose
+);
+
+public record Meta(
+    [property: JsonProperty("currency", NullValueHandling = NullValueHandling.Ignore)] string Currency,
+    [property: JsonProperty("symbol", NullValueHandling = NullValueHandling.Ignore)] string Symbol,
+    [property: JsonProperty("exchangeName", NullValueHandling = NullValueHandling.Ignore)] string ExchangeName,
+    [property: JsonProperty("fullExchangeName", NullValueHandling = NullValueHandling.Ignore)] string FullExchangeName,
+    [property: JsonProperty("instrumentType", NullValueHandling = NullValueHandling.Ignore)] string InstrumentType,
+    [property: JsonProperty("firstTradeDate", NullValueHandling = NullValueHandling.Ignore)] int? FirstTradeDate,
+    [property: JsonProperty("regularMarketTime", NullValueHandling = NullValueHandling.Ignore)] int? RegularMarketTime,
+    [property: JsonProperty("hasPrePostMarketData", NullValueHandling = NullValueHandling.Ignore)] bool? HasPrePostMarketData,
+    [property: JsonProperty("gmtoffset", NullValueHandling = NullValueHandling.Ignore)] int? Gmtoffset,
+    [property: JsonProperty("timezone", NullValueHandling = NullValueHandling.Ignore)] string Timezone,
+    [property: JsonProperty("exchangeTimezoneName", NullValueHandling = NullValueHandling.Ignore)] string ExchangeTimezoneName,
+    [property: JsonProperty("regularMarketPrice", NullValueHandling = NullValueHandling.Ignore)] double? RegularMarketPrice,
+    [property: JsonProperty("fiftyTwoWeekHigh", NullValueHandling = NullValueHandling.Ignore)] double? FiftyTwoWeekHigh,
+    [property: JsonProperty("fiftyTwoWeekLow", NullValueHandling = NullValueHandling.Ignore)] double? FiftyTwoWeekLow,
+    [property: JsonProperty("regularMarketDayHigh", NullValueHandling = NullValueHandling.Ignore)] double? RegularMarketDayHigh,
+    [property: JsonProperty("regularMarketDayLow", NullValueHandling = NullValueHandling.Ignore)] double? RegularMarketDayLow,
+    [property: JsonProperty("regularMarketVolume", NullValueHandling = NullValueHandling.Ignore)] int? RegularMarketVolume,
+    [property: JsonProperty("longName", NullValueHandling = NullValueHandling.Ignore)] string LongName,
+    [property: JsonProperty("shortName", NullValueHandling = NullValueHandling.Ignore)] string ShortName,
+    [property: JsonProperty("chartPreviousClose", NullValueHandling = NullValueHandling.Ignore)] double? ChartPreviousClose,
+    [property: JsonProperty("priceHint", NullValueHandling = NullValueHandling.Ignore)] int? PriceHint,
+    [property: JsonProperty("currentTradingPeriod", NullValueHandling = NullValueHandling.Ignore)] CurrentTradingPeriod CurrentTradingPeriod,
+    [property: JsonProperty("dataGranularity", NullValueHandling = NullValueHandling.Ignore)] string DataGranularity,
+    [property: JsonProperty("range", NullValueHandling = NullValueHandling.Ignore)] string Range,
+    [property: JsonProperty("validRanges", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<string> ValidRanges
+);
+
+public record Post(
+    [property: JsonProperty("timezone", NullValueHandling = NullValueHandling.Ignore)] string Timezone,
+    [property: JsonProperty("start", NullValueHandling = NullValueHandling.Ignore)] int? Start,
+    [property: JsonProperty("end", NullValueHandling = NullValueHandling.Ignore)] int? End,
+    [property: JsonProperty("gmtoffset", NullValueHandling = NullValueHandling.Ignore)] int? Gmtoffset
+);
+
+public record Pre(
+    [property: JsonProperty("timezone", NullValueHandling = NullValueHandling.Ignore)] string Timezone,
+    [property: JsonProperty("start", NullValueHandling = NullValueHandling.Ignore)] int? Start,
+    [property: JsonProperty("end", NullValueHandling = NullValueHandling.Ignore)] int? End,
+    [property: JsonProperty("gmtoffset", NullValueHandling = NullValueHandling.Ignore)] int? Gmtoffset
+);
+
+public record Quote(
+    [property: JsonProperty("close", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<double?> Close,
+    [property: JsonProperty("high", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<double?> High,
+    [property: JsonProperty("low", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<double?> Low,
+    [property: JsonProperty("volume", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<int?> Volume,
+    [property: JsonProperty("open", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<double?> Open
+);
+
+public record Regular(
+    [property: JsonProperty("timezone", NullValueHandling = NullValueHandling.Ignore)] string Timezone,
+    [property: JsonProperty("start", NullValueHandling = NullValueHandling.Ignore)] int? Start,
+    [property: JsonProperty("end", NullValueHandling = NullValueHandling.Ignore)] int? End,
+    [property: JsonProperty("gmtoffset", NullValueHandling = NullValueHandling.Ignore)] int? Gmtoffset
+);
+
+public record Result(
+    [property: JsonProperty("meta", NullValueHandling = NullValueHandling.Ignore)] Meta Meta,
+    [property: JsonProperty("timestamp", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<int?> Timestamp,
+    [property: JsonProperty("events", NullValueHandling = NullValueHandling.Ignore)] Events Events,
+    [property: JsonProperty("indicators", NullValueHandling = NullValueHandling.Ignore)] Indicators Indicators
+);
+
+public record Root(
+    [property: JsonProperty("chart", NullValueHandling = NullValueHandling.Ignore)] Chart Chart
+);

--- a/src/Models/DividendData.cs
+++ b/src/Models/DividendData.cs
@@ -1,103 +1,222 @@
 ﻿namespace OoplesFinance.YahooFinanceAPI.Models;
 
 [Serializable]
-public record DividendData(
-    [property: JsonProperty("amount", NullValueHandling = NullValueHandling.Ignore)] double? Amount,
-    [property: JsonProperty("date", NullValueHandling = NullValueHandling.Ignore)] int? Date
-);
 
-public record AdjClose(
-    [property: JsonProperty("adjclose", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<double?> Adjclose
-);
+public class AdjClose
+{
+    [JsonProperty("adjclose")]
+    public List<double?> Adjclose { get; set; } = [];
+}
 
-public record Chart(
-    [property: JsonProperty("result", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<Result> Result,
-    [property: JsonProperty("error", NullValueHandling = NullValueHandling.Ignore)] object Error
-);
+public class Chart
+{
+    [JsonProperty("result")]
+    public List<Result> Result { get; set; } = [];
 
-public record CurrentTradingPeriod(
-    [property: JsonProperty("pre", NullValueHandling = NullValueHandling.Ignore)] Pre Pre,
-    [property: JsonProperty("regular", NullValueHandling = NullValueHandling.Ignore)] Regular Regular,
-    [property: JsonProperty("post", NullValueHandling = NullValueHandling.Ignore)] Post Post
-);
+    [JsonProperty("error")]
+    public object Error { get; set; } = new();
+}
 
-public record Dividends(
-    [property: JsonProperty("dividends", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<DividendData> DividendsList
-);
+public class CurrentTradingPeriod
+{
+    [JsonProperty("pre")]
+    public Pre Pre { get; set; } = new();
 
-public record Events(
-    [property: JsonProperty("dividends", NullValueHandling = NullValueHandling.Ignore)] Dividends Dividends
-);
+    [JsonProperty("regular")]
+    public Regular Regular { get; set; } = new();
 
-public record Indicators(
-    [property: JsonProperty("quote", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<Quote> Quote,
-    [property: JsonProperty("adjclose", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<AdjClose> Adjclose
-);
+    [JsonProperty("post")]
+    public Post Post { get; set; } = new();
+}
 
-public record Meta(
-    [property: JsonProperty("currency", NullValueHandling = NullValueHandling.Ignore)] string Currency,
-    [property: JsonProperty("symbol", NullValueHandling = NullValueHandling.Ignore)] string Symbol,
-    [property: JsonProperty("exchangeName", NullValueHandling = NullValueHandling.Ignore)] string ExchangeName,
-    [property: JsonProperty("fullExchangeName", NullValueHandling = NullValueHandling.Ignore)] string FullExchangeName,
-    [property: JsonProperty("instrumentType", NullValueHandling = NullValueHandling.Ignore)] string InstrumentType,
-    [property: JsonProperty("firstTradeDate", NullValueHandling = NullValueHandling.Ignore)] int? FirstTradeDate,
-    [property: JsonProperty("regularMarketTime", NullValueHandling = NullValueHandling.Ignore)] int? RegularMarketTime,
-    [property: JsonProperty("hasPrePostMarketData", NullValueHandling = NullValueHandling.Ignore)] bool? HasPrePostMarketData,
-    [property: JsonProperty("gmtoffset", NullValueHandling = NullValueHandling.Ignore)] int? Gmtoffset,
-    [property: JsonProperty("timezone", NullValueHandling = NullValueHandling.Ignore)] string Timezone,
-    [property: JsonProperty("exchangeTimezoneName", NullValueHandling = NullValueHandling.Ignore)] string ExchangeTimezoneName,
-    [property: JsonProperty("regularMarketPrice", NullValueHandling = NullValueHandling.Ignore)] double? RegularMarketPrice,
-    [property: JsonProperty("fiftyTwoWeekHigh", NullValueHandling = NullValueHandling.Ignore)] double? FiftyTwoWeekHigh,
-    [property: JsonProperty("fiftyTwoWeekLow", NullValueHandling = NullValueHandling.Ignore)] double? FiftyTwoWeekLow,
-    [property: JsonProperty("regularMarketDayHigh", NullValueHandling = NullValueHandling.Ignore)] double? RegularMarketDayHigh,
-    [property: JsonProperty("regularMarketDayLow", NullValueHandling = NullValueHandling.Ignore)] double? RegularMarketDayLow,
-    [property: JsonProperty("regularMarketVolume", NullValueHandling = NullValueHandling.Ignore)] int? RegularMarketVolume,
-    [property: JsonProperty("longName", NullValueHandling = NullValueHandling.Ignore)] string LongName,
-    [property: JsonProperty("shortName", NullValueHandling = NullValueHandling.Ignore)] string ShortName,
-    [property: JsonProperty("chartPreviousClose", NullValueHandling = NullValueHandling.Ignore)] double? ChartPreviousClose,
-    [property: JsonProperty("priceHint", NullValueHandling = NullValueHandling.Ignore)] int? PriceHint,
-    [property: JsonProperty("currentTradingPeriod", NullValueHandling = NullValueHandling.Ignore)] CurrentTradingPeriod CurrentTradingPeriod,
-    [property: JsonProperty("dataGranularity", NullValueHandling = NullValueHandling.Ignore)] string DataGranularity,
-    [property: JsonProperty("range", NullValueHandling = NullValueHandling.Ignore)] string Range,
-    [property: JsonProperty("validRanges", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<string> ValidRanges
-);
+public class Dividends
+{
+    [JsonProperty("amount")]
+    public double? Amount { get; set; }
 
-public record Post(
-    [property: JsonProperty("timezone", NullValueHandling = NullValueHandling.Ignore)] string Timezone,
-    [property: JsonProperty("start", NullValueHandling = NullValueHandling.Ignore)] int? Start,
-    [property: JsonProperty("end", NullValueHandling = NullValueHandling.Ignore)] int? End,
-    [property: JsonProperty("gmtoffset", NullValueHandling = NullValueHandling.Ignore)] int? Gmtoffset
-);
+    [JsonProperty("date")]
+    public int? Date { get; set; }
+}
 
-public record Pre(
-    [property: JsonProperty("timezone", NullValueHandling = NullValueHandling.Ignore)] string Timezone,
-    [property: JsonProperty("start", NullValueHandling = NullValueHandling.Ignore)] int? Start,
-    [property: JsonProperty("end", NullValueHandling = NullValueHandling.Ignore)] int? End,
-    [property: JsonProperty("gmtoffset", NullValueHandling = NullValueHandling.Ignore)] int? Gmtoffset
-);
+public class Events
+{
+    [JsonProperty("dividends")]
+    public Dictionary<long, Dividends> DividendData { get; set; } = new();
+}
 
-public record Quote(
-    [property: JsonProperty("close", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<double?> Close,
-    [property: JsonProperty("high", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<double?> High,
-    [property: JsonProperty("low", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<double?> Low,
-    [property: JsonProperty("volume", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<int?> Volume,
-    [property: JsonProperty("open", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<double?> Open
-);
+public class Indicators
+{
+    [JsonProperty("quote")]
+    public List<Quote> Quote { get; set; } = [];
 
-public record Regular(
-    [property: JsonProperty("timezone", NullValueHandling = NullValueHandling.Ignore)] string Timezone,
-    [property: JsonProperty("start", NullValueHandling = NullValueHandling.Ignore)] int? Start,
-    [property: JsonProperty("end", NullValueHandling = NullValueHandling.Ignore)] int? End,
-    [property: JsonProperty("gmtoffset", NullValueHandling = NullValueHandling.Ignore)] int? Gmtoffset
-);
+    [JsonProperty("adjclose")]
+    public List<AdjClose> Adjclose { get; set; } = [];
+}
 
-public record Result(
-    [property: JsonProperty("meta", NullValueHandling = NullValueHandling.Ignore)] Meta Meta,
-    [property: JsonProperty("timestamp", NullValueHandling = NullValueHandling.Ignore)] IReadOnlyList<int?> Timestamp,
-    [property: JsonProperty("events", NullValueHandling = NullValueHandling.Ignore)] Events Events,
-    [property: JsonProperty("indicators", NullValueHandling = NullValueHandling.Ignore)] Indicators Indicators
-);
+public class Meta
+{
+    [JsonProperty("currency")]
+    public string Currency { get; set; } = string.Empty;
 
-public record Root(
-    [property: JsonProperty("chart", NullValueHandling = NullValueHandling.Ignore)] Chart Chart
-);
+    [JsonProperty("symbol")]
+    public string Symbol { get; set; } = string.Empty;
+
+    [JsonProperty("exchangeName")]
+    public string ExchangeName { get; set; } = string.Empty;
+
+    [JsonProperty("fullExchangeName")]
+    public string FullExchangeName { get; set; } = string.Empty;
+
+    [JsonProperty("instrumentType")]
+    public string InstrumentType { get; set; } = string.Empty;
+
+    [JsonProperty("firstTradeDate")]
+    public int? FirstTradeDate { get; set; }
+
+    [JsonProperty("regularMarketTime")]
+    public int? RegularMarketTime { get; set; }
+
+    [JsonProperty("hasPrePostMarketData")]
+    public bool? HasPrePostMarketData { get; set; }
+
+    [JsonProperty("gmtoffset")]
+    public int? Gmtoffset { get; set; }
+
+    [JsonProperty("timezone")]
+    public string Timezone { get; set; } = string.Empty;
+
+    [JsonProperty("exchangeTimezoneName")]
+    public string ExchangeTimezoneName { get; set; } = string.Empty;
+
+    [JsonProperty("regularMarketPrice")]
+    public double? RegularMarketPrice { get; set; }
+
+    [JsonProperty("fiftyTwoWeekHigh")]
+    public double? FiftyTwoWeekHigh { get; set; }
+
+    [JsonProperty("fiftyTwoWeekLow")]
+    public double? FiftyTwoWeekLow { get; set; }
+
+    [JsonProperty("regularMarketDayHigh")]
+    public double? RegularMarketDayHigh { get; set; }
+
+    [JsonProperty("regularMarketDayLow")]
+    public double? RegularMarketDayLow { get; set; }
+
+    [JsonProperty("regularMarketVolume")]
+    public int? RegularMarketVolume { get; set; }
+
+    [JsonProperty("longName")]
+    public string LongName { get; set; } = string.Empty;
+
+    [JsonProperty("shortName")]
+    public string ShortName { get; set; } = string.Empty;
+
+    [JsonProperty("chartPreviousClose")]
+    public double? ChartPreviousClose { get; set; }
+
+    [JsonProperty("priceHint")]
+    public int? PriceHint { get; set; }
+
+    [JsonProperty("currentTradingPeriod")]
+    public CurrentTradingPeriod CurrentTradingPeriod { get; set; } = new();
+
+    [JsonProperty("dataGranularity")]
+    public string DataGranularity { get; set; } = string.Empty;
+
+    [JsonProperty("range")]
+    public string Range { get; set; } = string.Empty;
+
+    [JsonProperty("validRanges")]
+    public List<string> ValidRanges { get; set; } = [];
+}
+
+public class Post
+{
+    [JsonProperty("timezone")]
+    public string Timezone { get; set; } = string.Empty;
+
+    [JsonProperty("start")]
+    public int? Start { get; set; }
+
+    [JsonProperty("end")]
+    public int? End { get; set; }
+
+    [JsonProperty("gmtoffset")]
+    public int? Gmtoffset { get; set; }
+}
+
+public class Pre
+{
+    [JsonProperty("timezone")]
+    public string Timezone { get; set; } = string.Empty;
+
+    [JsonProperty("start")]
+    public int? Start { get; set; }
+
+    [JsonProperty("end")]
+    public int? End { get; set; }
+
+    [JsonProperty("gmtoffset")]
+    public int? Gmtoffset { get; set; }
+}
+
+public class Quote
+{
+    [JsonProperty("close")]
+    public List<double?> Close { get; set; } = [];
+
+    [JsonProperty("high")]
+    public List<double?> High { get; set; } = [];
+
+    [JsonProperty("low")]
+    public List<double?> Low { get; set; } = [];
+
+    [JsonProperty("volume")]
+    public List<int?> Volume { get; set; } = [];
+
+    [JsonProperty("open")]
+    public List<double?> Open { get; set; } = [];
+}
+
+public class Regular
+{
+    [JsonProperty("timezone")]
+    public string Timezone { get; set; } = string.Empty;
+
+    [JsonProperty("start")]
+    public int? Start { get; set; }
+
+    [JsonProperty("end")]
+    public int? End { get; set; }
+
+    [JsonProperty("gmtoffset")]
+    public int? Gmtoffset { get; set; }
+}
+
+public class Result
+{
+    [JsonProperty("meta")]
+    public Meta Meta { get; set; } = new();
+
+    [JsonProperty("timestamp")]
+    public List<int?> Timestamp { get; set; } = [];
+
+    [JsonProperty("events")]
+    public Events Events { get; set; } = new();
+
+    [JsonProperty("indicators")]
+    public Indicators Indicators { get; set; } = new();
+}
+
+public class DividendRoot
+{
+    [JsonProperty("chart")]
+    public Chart Chart { get; set; } = new();
+}
+
+public partial class DividendItem
+{
+    public long Name {get; set;}
+    public Dividends DividendDataObject { get; set; } = new();
+}

--- a/src/Models/DividendData.cs
+++ b/src/Models/DividendData.cs
@@ -1,17 +1,16 @@
 ﻿namespace OoplesFinance.YahooFinanceAPI.Models;
 
 [Serializable]
-
 public class AdjClose
 {
     [JsonProperty("adjclose")]
     public List<double?> Adjclose { get; set; } = [];
 }
 
-public class Chart
+public class DividendChart
 {
     [JsonProperty("result")]
-    public List<Result> Result { get; set; } = [];
+    public List<DividendResult> Result { get; set; } = [];
 
     [JsonProperty("error")]
     public object Error { get; set; } = new();
@@ -38,7 +37,7 @@ public class Dividends
     public int? Date { get; set; }
 }
 
-public class Events
+public class DividendEvents
 {
     [JsonProperty("dividends")]
     public Dictionary<long, Dividends> DividendData { get; set; } = new();
@@ -194,7 +193,7 @@ public class Regular
     public int? Gmtoffset { get; set; }
 }
 
-public class Result
+public class DividendResult
 {
     [JsonProperty("meta")]
     public Meta Meta { get; set; } = new();
@@ -203,7 +202,7 @@ public class Result
     public List<int?> Timestamp { get; set; } = [];
 
     [JsonProperty("events")]
-    public Events Events { get; set; } = new();
+    public DividendEvents Events { get; set; } = new();
 
     [JsonProperty("indicators")]
     public Indicators Indicators { get; set; } = new();
@@ -212,7 +211,7 @@ public class Result
 public class DividendRoot
 {
     [JsonProperty("chart")]
-    public Chart Chart { get; set; } = new();
+    public DividendChart Chart { get; set; } = new();
 }
 
 public partial class DividendItem

--- a/src/Models/HistoricalData.cs
+++ b/src/Models/HistoricalData.cs
@@ -7,3 +7,24 @@ public class HistoricalDataRoot
     [JsonProperty("chart")]
     public Chart? Chart { get; set; }
 }
+
+public class Chart
+{
+    [JsonProperty("result")]
+    public List<Result> Result { get; set; } = [];
+
+    [JsonProperty("error")]
+    public object Error { get; set; } = new();
+}
+
+public class Result
+{
+    [JsonProperty("meta")]
+    public Meta Meta { get; set; } = new();
+
+    [JsonProperty("timestamp")]
+    public List<int?> Timestamp { get; set; } = [];
+
+    [JsonProperty("indicators")]
+    public Indicators Indicators { get; set; } = new();
+}

--- a/src/Models/HistoricalData.cs
+++ b/src/Models/HistoricalData.cs
@@ -1,58 +1,13 @@
 ﻿namespace OoplesFinance.YahooFinanceAPI.Models;
 
 [Serializable]
-public class Adjclose
-{
-    [JsonProperty("adjclose")]
-    public List<double?> AdjClose { get; set; } = [];
-}
-
-public class Chart
-{
-    [JsonProperty("result")]
-    public List<HistoricalDataResult> Result { get; set; } = [];
-
-    [JsonProperty("error")]
-    public object Error { get; set; } = new();
-}
-
 public class HistoricalDataIndicators
 {
     [JsonProperty("quote")]
     public List<HistoricalDataQuote> Quote { get; set; } = [];
 
     [JsonProperty("adjclose")]
-    public List<Adjclose> Adjclose { get; set; } = [];
-}
-
-public class Post
-{
-    [JsonProperty("timezone")]
-    public string Timezone { get; set; } = string.Empty;
-
-    [JsonProperty("start")]
-    public int? Start { get; set; }
-
-    [JsonProperty("end")]
-    public int? End { get; set; }
-
-    [JsonProperty("gmtoffset")]
-    public int? Gmtoffset { get; set; }
-}
-
-public class Pre
-{
-    [JsonProperty("timezone")]
-    public string Timezone { get; set; } = string.Empty;
-
-    [JsonProperty("start")]
-    public int? Start { get; set; }
-
-    [JsonProperty("end")]
-    public int? End { get; set; }
-
-    [JsonProperty("gmtoffset")]
-    public int? Gmtoffset { get; set; }
+    public List<AdjClose> Adjclose { get; set; } = [];
 }
 
 public class HistoricalDataQuote
@@ -73,35 +28,20 @@ public class HistoricalDataQuote
     public List<int?> Volume { get; set; } = [];
 }
 
-public class Regular
-{
-    [JsonProperty("timezone")]
-    public string Timezone { get; set; } = string.Empty;
-
-    [JsonProperty("start")]
-    public int? Start { get; set; }
-
-    [JsonProperty("end")]
-    public int? End { get; set; }
-
-    [JsonProperty("gmtoffset")]
-    public int? Gmtoffset { get; set; }
-}
-
 public class HistoricalDataResult
 {
     [JsonProperty("meta")]
-    public Meta Meta { get; set; } = new();
+    public Meta? Meta { get; set; }
 
     [JsonProperty("timestamp")]
     public List<int?> Timestamp { get; set; } = [];
 
     [JsonProperty("indicators")]
-    public Indicators Indicators { get; set; } = new();
+    public Indicators? Indicators { get; set; }
 }
 
 public class HistoricalDataRoot
 {
     [JsonProperty("chart")]
-    public Chart Chart { get; set; } = new();
+    public Chart? Chart { get; set; }
 }

--- a/src/Models/HistoricalData.cs
+++ b/src/Models/HistoricalData.cs
@@ -1,19 +1,107 @@
 ﻿namespace OoplesFinance.YahooFinanceAPI.Models;
 
 [Serializable]
-public class HistoricalData
+public class Adjclose
 {
-    public DateTime Date { get; set; }
+    [JsonProperty("adjclose")]
+    public List<double?> AdjClose { get; set; } = [];
+}
 
-    public double Open { get; set; }
+public class Chart
+{
+    [JsonProperty("result")]
+    public List<HistoricalDataResult> Result { get; set; } = [];
 
-    public double High { get; set; }
+    [JsonProperty("error")]
+    public object Error { get; set; } = new();
+}
 
-    public double Low { get; set; }
+public class HistoricalDataIndicators
+{
+    [JsonProperty("quote")]
+    public List<HistoricalDataQuote> Quote { get; set; } = [];
 
-    public double Close { get; set; }
+    [JsonProperty("adjclose")]
+    public List<Adjclose> Adjclose { get; set; } = [];
+}
 
-    public double AdjClose { get; set; }
+public class Post
+{
+    [JsonProperty("timezone")]
+    public string Timezone { get; set; } = string.Empty;
 
-    public double Volume { get; set; }
+    [JsonProperty("start")]
+    public int? Start { get; set; }
+
+    [JsonProperty("end")]
+    public int? End { get; set; }
+
+    [JsonProperty("gmtoffset")]
+    public int? Gmtoffset { get; set; }
+}
+
+public class Pre
+{
+    [JsonProperty("timezone")]
+    public string Timezone { get; set; } = string.Empty;
+
+    [JsonProperty("start")]
+    public int? Start { get; set; }
+
+    [JsonProperty("end")]
+    public int? End { get; set; }
+
+    [JsonProperty("gmtoffset")]
+    public int? Gmtoffset { get; set; }
+}
+
+public class HistoricalDataQuote
+{
+    [JsonProperty("high")]
+    public List<double?> High { get; set; } = [];
+
+    [JsonProperty("low")]
+    public List<double?> Low { get; set; } = [];
+
+    [JsonProperty("close")]
+    public List<double?> Close { get; set; } = [];
+
+    [JsonProperty("open")]
+    public List<double?> Open { get; set; } = [];
+
+    [JsonProperty("volume")]
+    public List<int?> Volume { get; set; } = [];
+}
+
+public class Regular
+{
+    [JsonProperty("timezone")]
+    public string Timezone { get; set; } = string.Empty;
+
+    [JsonProperty("start")]
+    public int? Start { get; set; }
+
+    [JsonProperty("end")]
+    public int? End { get; set; }
+
+    [JsonProperty("gmtoffset")]
+    public int? Gmtoffset { get; set; }
+}
+
+public class HistoricalDataResult
+{
+    [JsonProperty("meta")]
+    public Meta Meta { get; set; } = new();
+
+    [JsonProperty("timestamp")]
+    public List<int?> Timestamp { get; set; } = [];
+
+    [JsonProperty("indicators")]
+    public Indicators Indicators { get; set; } = new();
+}
+
+public class HistoricalDataRoot
+{
+    [JsonProperty("chart")]
+    public Chart Chart { get; set; } = new();
 }

--- a/src/Models/HistoricalData.cs
+++ b/src/Models/HistoricalData.cs
@@ -1,44 +1,6 @@
 ﻿namespace OoplesFinance.YahooFinanceAPI.Models;
 
 [Serializable]
-public class HistoricalDataIndicators
-{
-    [JsonProperty("quote")]
-    public List<HistoricalDataQuote> Quote { get; set; } = [];
-
-    [JsonProperty("adjclose")]
-    public List<AdjClose> Adjclose { get; set; } = [];
-}
-
-public class HistoricalDataQuote
-{
-    [JsonProperty("high")]
-    public List<double?> High { get; set; } = [];
-
-    [JsonProperty("low")]
-    public List<double?> Low { get; set; } = [];
-
-    [JsonProperty("close")]
-    public List<double?> Close { get; set; } = [];
-
-    [JsonProperty("open")]
-    public List<double?> Open { get; set; } = [];
-
-    [JsonProperty("volume")]
-    public List<int?> Volume { get; set; } = [];
-}
-
-public class HistoricalDataResult
-{
-    [JsonProperty("meta")]
-    public Meta? Meta { get; set; }
-
-    [JsonProperty("timestamp")]
-    public List<int?> Timestamp { get; set; } = [];
-
-    [JsonProperty("indicators")]
-    public Indicators? Indicators { get; set; }
-}
 
 public class HistoricalDataRoot
 {

--- a/src/Models/StockSplitData.cs
+++ b/src/Models/StockSplitData.cs
@@ -1,8 +1,60 @@
 ﻿namespace OoplesFinance.YahooFinanceAPI.Models;
 
 [Serializable]
-public class StockSplitData
+
+public class StockSplitRoot
 {
-    public DateTime Date { get; set; }
-    public string StockSplit { get; set; } = default!;
+    [JsonProperty("chart")]
+    public StockSplitChart Chart { get; set; } = new();
+}
+
+public class StockSplitResult
+{
+    [JsonProperty("meta")]
+    public Meta Meta { get; set; } = new();
+
+    [JsonProperty("timestamp")]
+    public List<int?> Timestamp { get; set; } = [];
+
+    [JsonProperty("events")]
+    public StockSplitEvents Events { get; set; } = new();
+
+    [JsonProperty("indicators")]
+    public Indicators Indicators { get; set; } = new();
+}
+
+public class StockSplitChart
+{
+    [JsonProperty("result")]
+    public List<StockSplitResult> Result { get; set; } = new();
+
+    [JsonProperty("error")]
+    public object Error { get; set; } = new();
+}
+
+public class StockSplitEvents
+{
+    [JsonProperty("splits")]
+    public Dictionary<long, Splits> SplitData { get; set; } = new();
+}
+
+public partial class SplitItem
+{
+    public long Name {get; set;}
+    public Splits SplitDataObject { get; set; } = new();
+}
+
+public class Splits
+{
+    [JsonProperty("date")]
+    public long? Date { get; set; }
+
+    [JsonProperty("numerator")]
+    public long? Numerator { get; set; }
+
+    [JsonProperty("denominator")]
+    public long? Denominator { get; set; }
+
+    [JsonProperty("splitRatio")]
+    public string SplitRatio { get; set; } = string.Empty;
 }

--- a/src/Models/TrendingData.cs
+++ b/src/Models/TrendingData.cs
@@ -9,7 +9,7 @@ internal class TrendingFinance
     public object Error { get; set; } = new();
 }
 
-internal class Quote
+internal class TrendingQuote
 {
     [JsonProperty("symbol")]
     public string Symbol { get; set; } = string.Empty;
@@ -21,7 +21,7 @@ internal class TrendingResult
     public int? Count { get; set; }
 
     [JsonProperty("quotes")]
-    public List<Quote> Quotes { get; set; } = [];
+    public List<TrendingQuote> Quotes { get; set; } = [];
 
     [JsonProperty("jobTimestamp")]
     public long? JobTimestamp { get; set; }

--- a/src/Models/UpgradeDowngradeHistoryData.cs
+++ b/src/Models/UpgradeDowngradeHistoryData.cs
@@ -21,13 +21,13 @@ public class History
 public class UpgradeDowngradeHistoryQuoteSummary
 {
     [JsonProperty("result")] 
-    public List<Result> Results { get; set; } = [];
+    public List<UpgradeDowngradeHistoryResult> Results { get; set; } = [];
 
     [JsonProperty("error")]
     public object Error { get; set; } = new();
 }
 
-public class Result
+public class UpgradeDowngradeHistoryResult
 {
     [JsonProperty("upgradeDowngradeHistory")] 
     public UpgradeDowngradeHistory UpgradeDowngradeHistory { get; set; } = new();

--- a/src/OoplesFinance.YahooFinanceAPI.csproj
+++ b/src/OoplesFinance.YahooFinanceAPI.csproj
@@ -8,7 +8,7 @@
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
 	<Title>Ooples Finance Yahoo Finance API</Title>
-	<Version>1.6.4</Version>
+	<Version>1.6.5</Version>
 	<Authors>ooples</Authors>
 	<Company>Ooples Finance</Company>
 	<Copyright>Ooples Finance LLC 2022-2023</Copyright>

--- a/src/YahooClient.cs
+++ b/src/YahooClient.cs
@@ -19,9 +19,9 @@ public class YahooClient
     /// <param name="dataFrequency"></param>
     /// <param name="startDate"></param>
     /// <returns></returns>
-    public async Task<HistoricalDataQuote> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
+    public async Task<Quote> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
     {
-        return new HistoricalHelper().ParseYahooJsonData<HistoricalDataQuote>(
+        return new HistoricalHelper().ParseYahooJsonData<Quote>(
             await DownloadRawCsvDataAsync(symbol, DataType.HistoricalPrices, dataFrequency, startDate, null, true)).First();
     }
 
@@ -33,10 +33,10 @@ public class YahooClient
     /// <param name="startDate"></param>
     /// <param name="endDate"></param>
     /// <returns></returns>
-    public async Task<HistoricalDataQuote> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency,
+    public async Task<Quote> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate)
     {
-        return new HistoricalHelper().ParseYahooJsonData<HistoricalDataQuote>(
+        return new HistoricalHelper().ParseYahooJsonData<Quote>(
             await DownloadRawCsvDataAsync(symbol, DataType.HistoricalPrices, dataFrequency, startDate, endDate, true)).First();
     }
 
@@ -49,10 +49,10 @@ public class YahooClient
     /// <param name="endDate"></param>
     /// <param name="includeAdjustedClose"></param>
     /// <returns></returns>
-    public async Task<HistoricalDataQuote> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency,
+    public async Task<Quote> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate, bool includeAdjustedClose)
     {
-        return new HistoricalHelper().ParseYahooJsonData<HistoricalDataQuote>(
+        return new HistoricalHelper().ParseYahooJsonData<Quote>(
             await DownloadRawCsvDataAsync(symbol, DataType.HistoricalPrices, dataFrequency, startDate, endDate, includeAdjustedClose)).First();
     }
 
@@ -63,9 +63,9 @@ public class YahooClient
     /// <param name="dataFrequency"></param>
     /// <param name="startDate"></param>
     /// <returns></returns>
-    public async Task<IEnumerable<DividendData>> GetDividendDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
+    public async Task<IEnumerable<Result>> GetDividendDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
     {
-        return new DividendHelper().ParseYahooJsonData<DividendData>(
+        return new DividendHelper().ParseYahooJsonData<Result>(
             await DownloadRawCsvDataAsync(symbol, DataType.Dividends, dataFrequency, startDate, null, true));
     }
 
@@ -77,10 +77,10 @@ public class YahooClient
     /// <param name="startDate"></param>
     /// <param name="endDate"></param>
     /// <returns></returns>
-    public async Task<IEnumerable<DividendData>> GetDividendDataAsync(string symbol, DataFrequency dataFrequency,
+    public async Task<IEnumerable<Result>> GetDividendDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate)
     {
-        return new DividendHelper().ParseYahooJsonData<DividendData>(
+        return new DividendHelper().ParseYahooJsonData<Result>(
             await DownloadRawCsvDataAsync(symbol, DataType.Dividends, dataFrequency, startDate, endDate, true));
     }
 
@@ -93,10 +93,10 @@ public class YahooClient
     /// <param name="endDate"></param>
     /// <param name="includeAdjustedClose"></param>
     /// <returns></returns>
-    public async Task<IEnumerable<DividendData>> GetDividendDataAsync(string symbol, DataFrequency dataFrequency,
+    public async Task<IEnumerable<Result>> GetDividendDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate, bool includeAdjustedClose)
     {
-        return new DividendHelper().ParseYahooJsonData<DividendData>(
+        return new DividendHelper().ParseYahooJsonData<Result>(
             await DownloadRawCsvDataAsync(symbol, DataType.Dividends, dataFrequency, startDate, endDate, includeAdjustedClose));
     }
 

--- a/src/YahooClient.cs
+++ b/src/YahooClient.cs
@@ -65,7 +65,7 @@ public class YahooClient
     /// <returns></returns>
     public async Task<IEnumerable<DividendData>> GetDividendDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
     {
-        return new DividendHelper().ParseYahooCsvData<DividendData>(
+        return new DividendHelper().ParseYahooJsonData<DividendData>(
             await DownloadRawCsvDataAsync(symbol, DataType.Dividends, dataFrequency, startDate, null, true));
     }
 
@@ -80,7 +80,7 @@ public class YahooClient
     public async Task<IEnumerable<DividendData>> GetDividendDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate)
     {
-        return new DividendHelper().ParseYahooCsvData<DividendData>(
+        return new DividendHelper().ParseYahooJsonData<DividendData>(
             await DownloadRawCsvDataAsync(symbol, DataType.Dividends, dataFrequency, startDate, endDate, true));
     }
 
@@ -96,7 +96,7 @@ public class YahooClient
     public async Task<IEnumerable<DividendData>> GetDividendDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate, bool includeAdjustedClose)
     {
-        return new DividendHelper().ParseYahooCsvData<DividendData>(
+        return new DividendHelper().ParseYahooJsonData<DividendData>(
             await DownloadRawCsvDataAsync(symbol, DataType.Dividends, dataFrequency, startDate, endDate, includeAdjustedClose));
     }
 
@@ -109,7 +109,7 @@ public class YahooClient
     /// <returns></returns>
     public async Task<IEnumerable<StockSplitData>> GetStockSplitDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
     {
-        return new StockSplitHelper().ParseYahooCsvData<StockSplitData>(
+        return new StockSplitHelper().ParseYahooJsonData<StockSplitData>(
             await DownloadRawCsvDataAsync(symbol, DataType.StockSplits, dataFrequency, startDate, null, true));
     }
 
@@ -124,7 +124,7 @@ public class YahooClient
     public async Task<IEnumerable<StockSplitData>> GetStockSplitDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate)
     {
-        return new StockSplitHelper().ParseYahooCsvData<StockSplitData>(
+        return new StockSplitHelper().ParseYahooJsonData<StockSplitData>(
             await DownloadRawCsvDataAsync(symbol, DataType.StockSplits, dataFrequency, startDate, endDate, true));
     }
 
@@ -140,7 +140,7 @@ public class YahooClient
     public async Task<IEnumerable<StockSplitData>> GetStockSplitDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate, bool includeAdjustedClose)
     {
-        return new StockSplitHelper().ParseYahooCsvData<StockSplitData>(
+        return new StockSplitHelper().ParseYahooJsonData<StockSplitData>(
             await DownloadRawCsvDataAsync(symbol, DataType.StockSplits, dataFrequency, startDate, endDate, includeAdjustedClose));
     }
 
@@ -153,7 +153,7 @@ public class YahooClient
     /// <returns></returns>
     public async Task<IEnumerable<CapitalGainData>> GetCapitalGainDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
     {
-        return new CapitalGainHelper().ParseYahooCsvData<CapitalGainData>(
+        return new CapitalGainHelper().ParseYahooJsonData<CapitalGainData>(
             await DownloadRawCsvDataAsync(symbol, DataType.CapitalGains, dataFrequency, startDate, null, true));
     }
 
@@ -168,7 +168,7 @@ public class YahooClient
     public async Task<IEnumerable<CapitalGainData>> GetCapitalGainDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate)
     {
-        return new CapitalGainHelper().ParseYahooCsvData<CapitalGainData>(
+        return new CapitalGainHelper().ParseYahooJsonData<CapitalGainData>(
             await DownloadRawCsvDataAsync(symbol, DataType.CapitalGains, dataFrequency, startDate, endDate, true));
     }
 
@@ -184,7 +184,7 @@ public class YahooClient
     public async Task<IEnumerable<CapitalGainData>> GetCapitalGainDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate, bool includeAdjustedClose)
     {
-        return new CapitalGainHelper().ParseYahooCsvData<CapitalGainData>(
+        return new CapitalGainHelper().ParseYahooJsonData<CapitalGainData>(
             await DownloadRawCsvDataAsync(symbol, DataType.CapitalGains, dataFrequency, startDate, endDate, includeAdjustedClose));
     }
 

--- a/src/YahooClient.cs
+++ b/src/YahooClient.cs
@@ -19,10 +19,10 @@ public class YahooClient
     /// <param name="dataFrequency"></param>
     /// <param name="startDate"></param>
     /// <returns></returns>
-    public async Task<IEnumerable<HistoricalData>> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
+    public async Task<HistoricalDataQuote> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
     {
-        return new HistoricalHelper().ParseYahooCsvData<HistoricalData>(
-            await DownloadRawCsvDataAsync(symbol, DataType.HistoricalPrices, dataFrequency, startDate, null, true));
+        return new HistoricalHelper().ParseYahooJsonData<HistoricalDataQuote>(
+            await DownloadRawCsvDataAsync(symbol, DataType.HistoricalPrices, dataFrequency, startDate, null, true)).First();
     }
 
     /// <summary>
@@ -33,11 +33,11 @@ public class YahooClient
     /// <param name="startDate"></param>
     /// <param name="endDate"></param>
     /// <returns></returns>
-    public async Task<IEnumerable<HistoricalData>> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency,
+    public async Task<HistoricalDataQuote> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate)
     {
-        return new HistoricalHelper().ParseYahooCsvData<HistoricalData>(
-            await DownloadRawCsvDataAsync(symbol, DataType.HistoricalPrices, dataFrequency, startDate, endDate, true));
+        return new HistoricalHelper().ParseYahooJsonData<HistoricalDataQuote>(
+            await DownloadRawCsvDataAsync(symbol, DataType.HistoricalPrices, dataFrequency, startDate, endDate, true)).First();
     }
 
     /// <summary>
@@ -49,11 +49,11 @@ public class YahooClient
     /// <param name="endDate"></param>
     /// <param name="includeAdjustedClose"></param>
     /// <returns></returns>
-    public async Task<IEnumerable<HistoricalData>> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency,
+    public async Task<HistoricalDataQuote> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate, bool includeAdjustedClose)
     {
-        return new HistoricalHelper().ParseYahooCsvData<HistoricalData>(
-            await DownloadRawCsvDataAsync(symbol, DataType.HistoricalPrices, dataFrequency, startDate, endDate, includeAdjustedClose));
+        return new HistoricalHelper().ParseYahooJsonData<HistoricalDataQuote>(
+            await DownloadRawCsvDataAsync(symbol, DataType.HistoricalPrices, dataFrequency, startDate, endDate, includeAdjustedClose)).First();
     }
 
     /// <summary>

--- a/src/YahooClient.cs
+++ b/src/YahooClient.cs
@@ -19,10 +19,10 @@ public class YahooClient
     /// <param name="dataFrequency"></param>
     /// <param name="startDate"></param>
     /// <returns></returns>
-    public async Task<Quote> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
+    public async Task<IEnumerable<Result>> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
     {
-        return new HistoricalHelper().ParseYahooJsonData<Quote>(
-            await DownloadRawCsvDataAsync(symbol, DataType.HistoricalPrices, dataFrequency, startDate, null, true)).First();
+        return new HistoricalHelper().ParseYahooJsonData<Result>(
+            await DownloadRawCsvDataAsync(symbol, DataType.HistoricalPrices, dataFrequency, startDate, null, true));
     }
 
     /// <summary>
@@ -33,11 +33,11 @@ public class YahooClient
     /// <param name="startDate"></param>
     /// <param name="endDate"></param>
     /// <returns></returns>
-    public async Task<Quote> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency,
+    public async Task<IEnumerable<Result>> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate)
     {
-        return new HistoricalHelper().ParseYahooJsonData<Quote>(
-            await DownloadRawCsvDataAsync(symbol, DataType.HistoricalPrices, dataFrequency, startDate, endDate, true)).First();
+        return new HistoricalHelper().ParseYahooJsonData<Result>(
+            await DownloadRawCsvDataAsync(symbol, DataType.HistoricalPrices, dataFrequency, startDate, endDate, true));
     }
 
     /// <summary>
@@ -49,11 +49,11 @@ public class YahooClient
     /// <param name="endDate"></param>
     /// <param name="includeAdjustedClose"></param>
     /// <returns></returns>
-    public async Task<Quote> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency,
+    public async Task<IEnumerable<Result>> GetHistoricalDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate, bool includeAdjustedClose)
     {
-        return new HistoricalHelper().ParseYahooJsonData<Quote>(
-            await DownloadRawCsvDataAsync(symbol, DataType.HistoricalPrices, dataFrequency, startDate, endDate, includeAdjustedClose)).First();
+        return new HistoricalHelper().ParseYahooJsonData<Result>(
+            await DownloadRawCsvDataAsync(symbol, DataType.HistoricalPrices, dataFrequency, startDate, endDate, includeAdjustedClose));
     }
 
     /// <summary>
@@ -63,9 +63,9 @@ public class YahooClient
     /// <param name="dataFrequency"></param>
     /// <param name="startDate"></param>
     /// <returns></returns>
-    public async Task<IEnumerable<Result>> GetDividendDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
+    public async Task<IEnumerable<DividendResult>> GetDividendDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
     {
-        return new DividendHelper().ParseYahooJsonData<Result>(
+        return new DividendHelper().ParseYahooJsonData<DividendResult>(
             await DownloadRawCsvDataAsync(symbol, DataType.Dividends, dataFrequency, startDate, null, true));
     }
 
@@ -77,10 +77,10 @@ public class YahooClient
     /// <param name="startDate"></param>
     /// <param name="endDate"></param>
     /// <returns></returns>
-    public async Task<IEnumerable<Result>> GetDividendDataAsync(string symbol, DataFrequency dataFrequency,
+    public async Task<IEnumerable<DividendResult>> GetDividendDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate)
     {
-        return new DividendHelper().ParseYahooJsonData<Result>(
+        return new DividendHelper().ParseYahooJsonData<DividendResult>(
             await DownloadRawCsvDataAsync(symbol, DataType.Dividends, dataFrequency, startDate, endDate, true));
     }
 
@@ -93,10 +93,10 @@ public class YahooClient
     /// <param name="endDate"></param>
     /// <param name="includeAdjustedClose"></param>
     /// <returns></returns>
-    public async Task<IEnumerable<Result>> GetDividendDataAsync(string symbol, DataFrequency dataFrequency,
+    public async Task<IEnumerable<DividendResult>> GetDividendDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate, bool includeAdjustedClose)
     {
-        return new DividendHelper().ParseYahooJsonData<Result>(
+        return new DividendHelper().ParseYahooJsonData<DividendResult>(
             await DownloadRawCsvDataAsync(symbol, DataType.Dividends, dataFrequency, startDate, endDate, includeAdjustedClose));
     }
 
@@ -107,9 +107,9 @@ public class YahooClient
     /// <param name="dataFrequency"></param>
     /// <param name="startDate"></param>
     /// <returns></returns>
-    public async Task<IEnumerable<StockSplitData>> GetStockSplitDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
+    public async Task<IEnumerable<StockSplitResult>> GetStockSplitDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
     {
-        return new StockSplitHelper().ParseYahooJsonData<StockSplitData>(
+        return new StockSplitHelper().ParseYahooJsonData<StockSplitResult>(
             await DownloadRawCsvDataAsync(symbol, DataType.StockSplits, dataFrequency, startDate, null, true));
     }
 
@@ -121,10 +121,10 @@ public class YahooClient
     /// <param name="startDate"></param>
     /// <param name="endDate"></param>
     /// <returns></returns>
-    public async Task<IEnumerable<StockSplitData>> GetStockSplitDataAsync(string symbol, DataFrequency dataFrequency,
+    public async Task<IEnumerable<StockSplitResult>> GetStockSplitDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate)
     {
-        return new StockSplitHelper().ParseYahooJsonData<StockSplitData>(
+        return new StockSplitHelper().ParseYahooJsonData<StockSplitResult>(
             await DownloadRawCsvDataAsync(symbol, DataType.StockSplits, dataFrequency, startDate, endDate, true));
     }
 
@@ -137,10 +137,10 @@ public class YahooClient
     /// <param name="endDate"></param>
     /// <param name="includeAdjustedClose"></param>
     /// <returns></returns>
-    public async Task<IEnumerable<StockSplitData>> GetStockSplitDataAsync(string symbol, DataFrequency dataFrequency,
+    public async Task<IEnumerable<StockSplitResult>> GetStockSplitDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate, bool includeAdjustedClose)
     {
-        return new StockSplitHelper().ParseYahooJsonData<StockSplitData>(
+        return new StockSplitHelper().ParseYahooJsonData<StockSplitResult>(
             await DownloadRawCsvDataAsync(symbol, DataType.StockSplits, dataFrequency, startDate, endDate, includeAdjustedClose));
     }
 
@@ -151,9 +151,9 @@ public class YahooClient
     /// <param name="dataFrequency"></param>
     /// <param name="startDate"></param>
     /// <returns></returns>
-    public async Task<IEnumerable<CapitalGainData>> GetCapitalGainDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
+    public async Task<IEnumerable<Result>> GetCapitalGainDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
     {
-        return new CapitalGainHelper().ParseYahooJsonData<CapitalGainData>(
+        return new CapitalGainHelper().ParseYahooJsonData<Result>(
             await DownloadRawCsvDataAsync(symbol, DataType.CapitalGains, dataFrequency, startDate, null, true));
     }
 
@@ -165,10 +165,10 @@ public class YahooClient
     /// <param name="startDate"></param>
     /// <param name="endDate"></param>
     /// <returns></returns>
-    public async Task<IEnumerable<CapitalGainData>> GetCapitalGainDataAsync(string symbol, DataFrequency dataFrequency,
+    public async Task<IEnumerable<Result>> GetCapitalGainDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate)
     {
-        return new CapitalGainHelper().ParseYahooJsonData<CapitalGainData>(
+        return new CapitalGainHelper().ParseYahooJsonData<Result>(
             await DownloadRawCsvDataAsync(symbol, DataType.CapitalGains, dataFrequency, startDate, endDate, true));
     }
 
@@ -181,10 +181,10 @@ public class YahooClient
     /// <param name="endDate"></param>
     /// <param name="includeAdjustedClose"></param>
     /// <returns></returns>
-    public async Task<IEnumerable<CapitalGainData>> GetCapitalGainDataAsync(string symbol, DataFrequency dataFrequency,
+    public async Task<IEnumerable<Result>> GetCapitalGainDataAsync(string symbol, DataFrequency dataFrequency,
         DateTime startDate, DateTime? endDate, bool includeAdjustedClose)
     {
-        return new CapitalGainHelper().ParseYahooJsonData<CapitalGainData>(
+        return new CapitalGainHelper().ParseYahooJsonData<Result>(
             await DownloadRawCsvDataAsync(symbol, DataType.CapitalGains, dataFrequency, startDate, endDate, includeAdjustedClose));
     }
 

--- a/tests/TestConsoleApp/Program.cs
+++ b/tests/TestConsoleApp/Program.cs
@@ -9,6 +9,8 @@ try
     var symbols = new string[] { symbol, "MSFT", "NFLX", "TSLA", "YHOO", "SPY", "A", "AA", "GOOG", "F", "UBER", "LYFT" };
 
     var yahooClient = new YahooClient();
+    var dividendList = await yahooClient.GetDividendDataAsync(symbol, DataFrequency.Weekly, startDate);
+    Console.WriteLine();
     //var historicalDataList = await yahooClient.GetHistoricalDataAsync(symbol, DataFrequency.Daily, startDate);
     //var capitalGainList = await yahooClient.GetCapitalGainDataAsync(symbol, DataFrequency.Monthly, startDate);
     //var dividendList = await yahooClient.GetDividendDataAsync(symbol, DataFrequency.Weekly, startDate);

--- a/tests/TestConsoleApp/Program.cs
+++ b/tests/TestConsoleApp/Program.cs
@@ -3,14 +3,12 @@ using OoplesFinance.YahooFinanceAPI.Enums;
 
 try
 {
-    var startDate = DateTime.Now.AddYears(-1);
-    var symbol = "AAPL";
+    var startDate = DateTime.Now.AddYears(-10);
+    var symbol = "GOOG";
     var fundSymbol = "VSMPX";
     var symbols = new string[] { symbol, "MSFT", "NFLX", "TSLA", "YHOO", "SPY", "A", "AA", "GOOG", "F", "UBER", "LYFT" };
 
     var yahooClient = new YahooClient();
-    var dividendList = await yahooClient.GetDividendDataAsync(symbol, DataFrequency.Weekly, startDate);
-    Console.WriteLine();
     //var historicalDataList = await yahooClient.GetHistoricalDataAsync(symbol, DataFrequency.Daily, startDate);
     //var capitalGainList = await yahooClient.GetCapitalGainDataAsync(symbol, DataFrequency.Monthly, startDate);
     //var dividendList = await yahooClient.GetDividendDataAsync(symbol, DataFrequency.Weekly, startDate);

--- a/tests/UnitTests/OoplesFinance.YahooFinanceAPI.Tests.Unit.csproj
+++ b/tests/UnitTests/OoplesFinance.YahooFinanceAPI.Tests.Unit.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -9,23 +9,14 @@
 
   <ItemGroup>
 	<DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2023.2.2" />
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-    <PackageReference Include="xunit" Version="2.9.0" />
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/UnitTests/YahooClientTests.cs
+++ b/tests/UnitTests/YahooClientTests.cs
@@ -47,7 +47,7 @@ public sealed class YahooClientTests
         var result = await _sut.GetHistoricalDataAsync(GoodSymbol, DataFrequency.Daily, _startDate);
 
         // Assert
-        result.Should().NotBeEmpty();
+        result.Should().NotBeNull();
     }
 
     [Fact]


### PR DESCRIPTION
GetHistoricalDataAsync(), GetStockSplitInfoAsync(), GetCapitalGainInfoAsync(), and GetDividendInfoAsync() have all been moved to returning json data which is a breaking change. This had to be done since Yahoo didn't support the csv methods any longer.