### PR TITLE
Made sure volume value type was changed to long since it was throwing an exception for certain symbols

### DIFF
--- a/src/Helpers/ChartHelper.cs
+++ b/src/Helpers/ChartHelper.cs
@@ -18,7 +18,7 @@ internal class ChartHelper : YahooJsonBase
             CloseList = new List<double>(root != null ? root.Indicators?.Quote.SelectMany(x => x.Close.Select(y => y.GetValueOrDefault())) ?? [] : []),
             OpenList = new List<double>(root != null ? root.Indicators?.Quote.SelectMany(x => x.Open.Select(y => y.GetValueOrDefault())) ?? [] : []),
             HighList = new List<double>(root != null ? root.Indicators?.Quote.SelectMany(x => x.High.Select(y => y.GetValueOrDefault())) ?? [] : []),
-            VolumeList = new List<double>(root != null ? root.Indicators?.Quote.SelectMany(x => x.Volume.Select(y => (double)y.GetValueOrDefault())) ?? [] : []),
+            VolumeList = new List<long>(root != null ? root.Indicators?.Quote.SelectMany(x => x.Volume.Select(y => y.GetValueOrDefault())) ?? [] : []),
             LowList = new List<double>(root != null ? root.Indicators?.Quote.SelectMany(x => x.Low.Select(y => y.GetValueOrDefault())) ?? [] : [])
         };
 

--- a/src/Models/ChartData.cs
+++ b/src/Models/ChartData.cs
@@ -54,5 +54,5 @@ public class ChartInfo
 
     public List<double> CloseList { get; set; } = [];
 
-    public List<double> VolumeList { get; set; } = [];
+    public List<long> VolumeList { get; set; } = [];
 }

--- a/src/Models/DividendData.cs
+++ b/src/Models/DividendData.cs
@@ -172,7 +172,7 @@ public class Quote
     public List<double?> Low { get; set; } = [];
 
     [JsonProperty("volume")]
-    public List<int?> Volume { get; set; } = [];
+    public List<long?> Volume { get; set; } = [];
 
     [JsonProperty("open")]
     public List<double?> Open { get; set; } = [];

--- a/src/OoplesFinance.YahooFinanceAPI.csproj
+++ b/src/OoplesFinance.YahooFinanceAPI.csproj
@@ -8,7 +8,7 @@
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
 	<Title>Ooples Finance Yahoo Finance API</Title>
-	<Version>1.6.6</Version>
+	<Version>1.6.7</Version>
 	<Authors>ooples</Authors>
 	<Company>Ooples Finance</Company>
 	<Copyright>Ooples Finance LLC 2022-2023</Copyright>


### PR DESCRIPTION
#### PR Classification
API change to ensure consistency and accuracy in volume data handling.

#### PR Summary
Updated volume-related properties from `double` or `int` to `long` for consistency and accuracy.
- `ChartHelper.cs`: Changed `VolumeList` from `List<double>` to `List<long>`.
- `ChartData.cs`: Changed `VolumeList` in `ChartInfo` from `List<double>` to `List<long>`.
- `DividendData.cs`: Changed `Volume` in `Quote` from `List<int?>` to `List<long?>`.
