### PR TITLE
Throttling + All History Data

### DIFF
--- a/src/Enums/DataType.cs
+++ b/src/Enums/DataType.cs
@@ -5,5 +5,6 @@ public enum DataType
     HistoricalPrices,
     Dividends,
     StockSplits,
-    CapitalGains
+    CapitalGains,
+    All
 }

--- a/src/Helpers/AllHistoricalHelper.cs
+++ b/src/Helpers/AllHistoricalHelper.cs
@@ -1,0 +1,58 @@
+﻿// AllHistoricalHelper.cs
+//  Andrew Baylis
+//  Created: 12/10/2024
+
+namespace OoplesFinance.YahooFinanceAPI.Helpers;
+
+internal class AllHistoricalHelper
+{
+    #region Internal Methods
+
+    internal HistoricalFullData ParseYahooJsonData<T>(string jsonData)
+    {
+        var root = JsonConvert.DeserializeObject<HistoricalDataRoot>(jsonData)?.Chart?.Result.FirstOrDefault() ??
+                   throw new InvalidOperationException("No data available from Yahoo Finance");
+
+        var result = new HistoricalFullData {Meta = root.Meta};
+
+        for (var i = 0; i < root.Timestamp.Count; i++)
+        {
+            result.Prices.Add(new HistoricalChartInfo
+            {
+                Meta = root.Meta,
+                Date = root.Timestamp[i].GetValueOrDefault().FromUnixTimeStamp(),
+                Open = Math.Round(root.Indicators?.Quote.FirstOrDefault()?.Open[i] ?? 0, 4),
+                High = Math.Round(root.Indicators?.Quote.FirstOrDefault()?.High[i] ?? 0, 4),
+                Low = Math.Round(root.Indicators?.Quote.FirstOrDefault()?.Low[i] ?? 0, 4),
+                Close = Math.Round(root.Indicators?.Quote.FirstOrDefault()?.Close[i] ?? 0, 4),
+                AdjustedClose = Math.Round(root.Indicators?.Adjclose.FirstOrDefault()?.Adjclose[i] ?? 0, 4),
+                Volume = root.Indicators?.Quote.FirstOrDefault()?.Volume[i] ?? 0
+            });
+        }
+
+        if (result.Prices.Count == 0)
+        {
+            throw new InvalidOperationException("Requested Information Not Available On Yahoo Finance");
+        }
+
+        if (root.Events.DividendData.Count > 0)
+        {
+            foreach (var dividend in root.Events.DividendData)
+            {
+                result.Dividends.Add(new DividendInfo(dividend.Value));
+            }
+        }
+
+        if (root.Events.SplitData.Count > 0)
+        {
+            foreach (var split in root.Events.SplitData)
+            {
+                result.Splits.Add(new SplitInfo(split.Value));
+            }
+        }
+
+        return result;
+    }
+
+    #endregion
+}

--- a/src/Helpers/CrumbHelper.cs
+++ b/src/Helpers/CrumbHelper.cs
@@ -1,87 +1,188 @@
-﻿using System.Runtime.CompilerServices;
+﻿// CrumbHelper.cs
+
+#region using
+
+using System.Runtime.CompilerServices;
+
+#endregion
 
 [assembly: InternalsVisibleTo("OoplesFinance.YahooFinanceAPI.Tests.Unit")]
-namespace OoplesFinance.YahooFinanceAPI.Helpers
+
+namespace OoplesFinance.YahooFinanceAPI.Helpers;
+
+internal sealed class CrumbHelper
 {
-    internal sealed class CrumbHelper
+    #region Fields
+
+    private static CrumbHelper? _instance;
+
+    internal static HttpMessageHandler? handler;
+    private List<string> cookies = [];
+
+    #endregion
+
+    private CrumbHelper()
     {
-        /// <summary>
-        ///  Crumb value for the Yahoo Finance API
-        /// </summary>
-        internal string Crumb { get; private set; }
-        internal static HttpMessageHandler? handler;
-        private List<string> cookies = [];
-        private static CrumbHelper? _instance;
+        handler = GetClientHandler(); 
+        Crumb = string.Empty;
+    }
 
-        CrumbHelper()
+    #region Properties
+
+    /// <summary>
+    ///     Crumb value for the Yahoo Finance API
+    /// </summary>
+    internal string Crumb { get; private set; }
+
+    /// <summary>
+    ///     Single instance of the CrumbHelper
+    /// </summary>
+    private static CrumbHelper Instance
+    {
+        get { return _instance ??= new CrumbHelper(); }
+    }
+
+    #endregion
+
+    #region Static Methods
+
+    public static HttpClient GetHttpClient()
+    {
+        HttpClient client = new(handler ?? GetClientHandler());
+        client.DefaultRequestHeaders.Add("Cookie", Instance.cookies);
+        client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3");
+        client.DefaultRequestHeaders.Add("Cache-Control", "no-cache");
+        client.DefaultRequestHeaders.Add("Connection", "keep-alive");
+        client.DefaultRequestHeaders.Add("Pragma", "no-cache");
+        client.DefaultRequestHeaders.Add("Upgrade-Insecure-Requests", "1");
+
+        return client;
+    }
+
+    public static async Task<CrumbHelper> GetInstance()
+    {
+        if (string.IsNullOrEmpty(Instance.Crumb))
         {
-            handler = new HttpClientHandler();
-            Crumb = string.Empty;
+            await Instance.SetCrumbAsync();
         }
 
-        internal void Destroy()
-        {
-            _instance = null;
-        }
+        return Instance;
+    }
 
-        public async Task SetCrumbAsync()
-        {
-            var client = GetHttpClient();
-            var loginResponse = await client.GetAsync("https://login.yahoo.com/");            
+    private static HttpClientHandler GetClientHandler()
+    {
+        return YahooClient.IsThrottled
+            ? new DownloadThrottleQueueHandler(40, TimeSpan.FromMinutes(1)) //40 calls in a minute
+            : new HttpClientHandler();
+    }
 
-            if (loginResponse.IsSuccessStatusCode)
+    #endregion
+
+    #region Public Methods
+
+    public async Task SetCrumbAsync()
+    {
+        var client = GetHttpClient();
+        var loginResponse = await client.GetAsync("https://login.yahoo.com/");
+
+        if (loginResponse.IsSuccessStatusCode)
+        {
+            var login = await loginResponse.Content.ReadAsStringAsync();
+            if (loginResponse.Headers.TryGetValues("Set-Cookie", out var setCookie))
             {
-                var login = await loginResponse.Content.ReadAsStringAsync();
-                if (loginResponse.Headers.TryGetValues(name: "Set-Cookie", out IEnumerable<string>? setCookie))
-                {
-                    cookies = new List<string>(setCookie.Where(c => c.ToLower().IndexOf("domain=.yahoo.com") > 0));                   
-                    var crumbResponse = await client.GetAsync("https://query1.finance.yahoo.com/v1/test/getcrumb");
+                cookies = new List<string>(setCookie.Where(c => c.ToLower().IndexOf("domain=.yahoo.com") > 0));
+                var crumbResponse = await client.GetAsync("https://query1.finance.yahoo.com/v1/test/getcrumb");
 
-                    if (crumbResponse.IsSuccessStatusCode)
-                    {
-                        Crumb = await crumbResponse.Content.ReadAsStringAsync();
-                    }
+                if (crumbResponse.IsSuccessStatusCode)
+                {
+                    Crumb = await crumbResponse.Content.ReadAsStringAsync();
                 }
             }
-
-            if (string.IsNullOrEmpty(Crumb))
-            {
-                throw new Exception("Failed to get crumb");
-            }
         }
 
-        public static HttpClient GetHttpClient()
+        if (string.IsNullOrEmpty(Crumb))
         {
-            HttpClient client = new(handler ?? new HttpClientHandler());     
-            client.DefaultRequestHeaders.Add("Cookie", Instance.cookies);
-            client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3");
-            client.DefaultRequestHeaders.Add("Cache-Control", "no-cache");
-            client.DefaultRequestHeaders.Add("Connection", "keep-alive");
-            client.DefaultRequestHeaders.Add("Pragma", "no-cache");
-            client.DefaultRequestHeaders.Add("Upgrade-Insecure-Requests", "1");
-
-            return client;
-        }
-
-        public static async Task<CrumbHelper> GetInstance()
-        {
-            if (string.IsNullOrEmpty(Instance.Crumb))
-            {
-                await Instance.SetCrumbAsync();
-            }
-
-            return Instance;
-        }
-
-        /// <summary>
-        /// Single instance of the CrumbHelper
-        /// </summary>        
-        private static CrumbHelper Instance
-        {
-            get
-            {
-                return _instance ??= new CrumbHelper();
-            }
+            throw new Exception("Failed to get crumb");
         }
     }
+
+    #endregion
+
+    #region Internal Methods
+
+    internal void Destroy()
+    {
+        _instance = null;
+    }
+
+    #endregion
+}
+
+internal class DownloadThrottleQueueHandler : HttpClientHandler
+{
+    #region Fields
+
+    private readonly ThrottleService _throttle;
+
+    #endregion
+
+    public DownloadThrottleQueueHandler(int maxActions, TimeSpan maxPeriod)
+    {
+        _throttle = new ThrottleService(maxActions, maxPeriod);
+    }
+
+    #region Override Methods
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        return await _throttle.QueueAsync(async () => await base.SendAsync(request, cancellationToken), cancellationToken);
+    }
+
+    #endregion
+
+    #region Nested type: ThrottleService
+
+    private class ThrottleService
+    {
+        #region Fields
+
+        private readonly TimeSpan _maxPeriod;
+        private readonly SemaphoreSlim _throttleActions, _throttlePeriods;
+
+        #endregion
+
+        public ThrottleService(int maxActions, TimeSpan maxPeriod)
+        {
+            _throttleActions = new SemaphoreSlim(maxActions, maxActions);
+            _throttlePeriods = new SemaphoreSlim(maxActions, maxActions);
+            _maxPeriod = maxPeriod;
+        }
+
+        #region Public Methods
+
+        public async Task<T> QueueAsync<T>(Func<Task<T>> action, CancellationToken cancel)
+        {
+            await _throttleActions.WaitAsync(cancel);
+
+            try
+            {
+                await _throttlePeriods.WaitAsync(cancel);
+
+                // Release after period [Note: Intentionally not awaited]
+                // - Allow bursts up to maxActions requests at once
+                // - Do not allow more than maxActions requests per period
+                _ = Task.Delay(_maxPeriod).ContinueWith(tt => { _throttlePeriods.Release(1); }, cancel);
+
+                return await action();
+            }
+            finally
+            {
+                _throttleActions.Release();
+            }
+        }
+
+        #endregion
+    }
+
+    #endregion
 }

--- a/src/Helpers/ExternalInit.cs
+++ b/src/Helpers/ExternalInit.cs
@@ -1,3 +1,3 @@
-﻿namespace System.Runtime.CompilerServices;
+﻿namespace OoplesFinance.YahooFinanceAPI.Helpers;
 
 internal static class IsExternalInit { }

--- a/src/Helpers/UrlHelper.cs
+++ b/src/Helpers/UrlHelper.cs
@@ -284,10 +284,11 @@ internal static class UrlHelper
         dataType switch
         {
             DataType.HistoricalPrices => "history",
-            DataType.Dividends        => "div",
-            DataType.StockSplits      => "split",
-            DataType.CapitalGains     => "capitalGain",
-            _                         => throw new ArgumentException("Invalid Enumerator Value", nameof(dataType))
+            DataType.Dividends => "div",
+            DataType.StockSplits => "split",
+            DataType.CapitalGains => "capitalGain",
+            DataType.All => "history,div,split",
+            _ => throw new ArgumentException("Invalid Enumerator Value", nameof(dataType))
         };
 
     private static string GetScreenerString(ScreenerType screenerType) =>

--- a/src/Models/HistoricalData.cs
+++ b/src/Models/HistoricalData.cs
@@ -1,47 +1,140 @@
-﻿namespace OoplesFinance.YahooFinanceAPI.Models;
+﻿// HistoricalData.cs
+//  Andrew Baylis
+//  Created: 11/10/2024
+
+namespace OoplesFinance.YahooFinanceAPI.Models;
 
 [Serializable]
-
 public class HistoricalDataRoot
 {
+    #region Properties
+
     [JsonProperty("chart")]
     public Chart? Chart { get; set; }
+
+    #endregion
 }
 
 public class Chart
 {
-    [JsonProperty("result")]
-    public List<Result> Result { get; set; } = [];
+    #region Properties
 
     [JsonProperty("error")]
     public object Error { get; set; } = new();
+
+    [JsonProperty("result")]
+    public List<Result> Result { get; set; } = [];
+
+    #endregion
 }
 
 public class Result
 {
+    #region Properties
+
+    [JsonProperty("events")]
+    public HistoricalEvent Events { get; set; } = new();
+
+    [JsonProperty("indicators")]
+    public Indicators Indicators { get; set; } = new();
+
     [JsonProperty("meta")]
     public Meta Meta { get; set; } = new();
 
     [JsonProperty("timestamp")]
     public List<long?> Timestamp { get; set; } = [];
 
-    [JsonProperty("indicators")]
-    public Indicators Indicators { get; set; } = new();
+    #endregion
+}
+
+public class HistoricalEvent
+{
+    #region Properties
+
+    [JsonProperty("dividends")]
+    public Dictionary<long, Dividends> DividendData { get; set; } = new();
+
+    [JsonProperty("splits")]
+    public Dictionary<long, Splits> SplitData { get; set; } = new();
+
+    #endregion
 }
 
 public class HistoricalChartInfo
 {
-    public DateTime Date { get; set; }
+    #region Properties
 
-    public double Open { get; set; }
+    public double AdjustedClose { get; set; }
+
+    public double Close { get; set; }
+
+    public DateTime Date { get; set; }
 
     public double High { get; set; }
 
     public double Low { get; set; }
 
-    public double Close { get; set; }
+    public Meta Meta { get; set; } = new();
 
-    public double AdjustedClose { get; set; }
+    public double Open { get; set; }
 
     public long Volume { get; set; }
+
+    #endregion
+}
+
+public class HistoricalFullData
+{
+    #region Properties
+
+    public List<DividendInfo> Dividends { get; set; } = new();
+
+    public Meta Meta { get; set; } = new();
+
+    public List<HistoricalChartInfo> Prices { get; set; } = new();
+
+    public List<SplitInfo> Splits { get; set; } = new();
+
+    #endregion
+}
+
+public class DividendInfo
+{
+    public DividendInfo(Dividends d)
+    {
+        var dt = (long) d.Date.GetValueOrDefault();
+        Date = dt.FromUnixTimeStamp();
+        Amount = d.Amount;
+    }
+
+    #region Properties
+
+    public double? Amount { get; set; }
+
+    public DateTime Date { get; set; }
+
+    #endregion
+}
+
+public class SplitInfo
+{
+    public SplitInfo(Splits s)
+    {
+        Date = s.Date.GetValueOrDefault().FromUnixTimeStamp();
+        Denominator = s.Denominator;
+        Numerator = s.Numerator;
+        SplitRatio = s.SplitRatio;
+    }
+
+    #region Properties
+
+    public DateTime? Date { get; set; }
+
+    public long? Denominator { get; set; }
+
+    public long? Numerator { get; set; }
+
+    public string SplitRatio { get; set; }
+
+    #endregion
 }

--- a/src/YahooClient.cs
+++ b/src/YahooClient.cs
@@ -5,6 +5,8 @@ public class YahooClient
     private readonly Country Country;
 
     private readonly Language Language;
+    
+    public static bool IsThrottled { get; set; }
 
     public YahooClient(Country? country = null, Language? language = null)
     {
@@ -54,6 +56,50 @@ public class YahooClient
     {
         return new HistoricalHelper().ParseYahooJsonData<HistoricalChartInfo>(
             await DownloadRawCsvDataAsync(symbol, DataType.HistoricalPrices, dataFrequency, startDate, endDate, includeAdjustedClose));
+    }
+    
+    /// <summary>
+    /// Gets a list of all Historical Data for the selected stock symbol and parameter options.
+    /// </summary>
+    /// <param name="symbol"></param>
+    /// <param name="dataFrequency"></param>
+    /// <param name="startDate"></param>
+    /// <returns></returns>
+    public async Task<HistoricalFullData> GetAllHistoricalDataAsync(string symbol, DataFrequency dataFrequency, DateTime startDate)
+    {
+        return new AllHistoricalHelper().ParseYahooJsonData<HistoricalFullData>(
+            await DownloadRawCsvDataAsync(symbol, DataType.All, dataFrequency, startDate, null, true));
+    }
+    
+    /// <summary>
+    /// Gets a list of all Historical Data for the selected stock symbol and parameter options.
+    /// </summary>
+    /// <param name="symbol"></param>
+    /// <param name="dataFrequency"></param>
+    /// <param name="startDate"></param>
+    /// <param name="endDate"></param>
+    /// <returns></returns>
+    public async Task<HistoricalFullData> GetAllHistoricalDataAsync(string symbol, DataFrequency dataFrequency,
+        DateTime startDate, DateTime? endDate)
+    {
+        return new AllHistoricalHelper().ParseYahooJsonData<HistoricalFullData>(
+            await DownloadRawCsvDataAsync(symbol, DataType.All, dataFrequency, startDate, endDate, true));
+    }
+    
+    /// <summary>
+    /// Gets a list of all Historical Data for the selected stock symbol and parameter options.
+    /// </summary>
+    /// <param name="symbol"></param>
+    /// <param name="dataFrequency"></param>
+    /// <param name="startDate"></param>
+    /// <param name="endDate"></param>
+    /// <param name="includeAdjustedClose"></param>
+    /// <returns></returns>
+    public async Task<HistoricalFullData> GetAllHistoricalDataAsync(string symbol, DataFrequency dataFrequency,
+        DateTime startDate, DateTime? endDate, bool includeAdjustedClose)
+    {
+        return new AllHistoricalHelper().ParseYahooJsonData<HistoricalFullData>(
+            await DownloadRawCsvDataAsync(symbol, DataType.All, dataFrequency, startDate, endDate, includeAdjustedClose));
     }
 
     /// <summary>


### PR DESCRIPTION
Introduced a throttle approach (40 calls per minute) for YahooAPI calls, and created a new historical data call which downloads dividends, splits and prices in one call rather than three.