### PR TITLE
fix: crumb fetch didn't use cookie after it was fetched

### DIFF
--- a/src/Helpers/CrumbHelper.cs
+++ b/src/Helpers/CrumbHelper.cs
@@ -35,7 +35,7 @@ namespace OoplesFinance.YahooFinanceAPI.Helpers
                 if (loginResponse.Headers.TryGetValues(name: "Set-Cookie", out IEnumerable<string>? setCookie))
                 {
                     cookies = new List<string>(setCookie.Where(c => c.ToLower().IndexOf("domain=.yahoo.com") > 0));                   
-                    var crumbResponse = await client.GetAsync("https://query1.finance.yahoo.com/v1/test/getcrumb");
+                    var crumbResponse = await GetHttpClient().GetAsync("https://query1.finance.yahoo.com/v1/test/getcrumb");
 
                     if (crumbResponse.IsSuccessStatusCode)
                     {


### PR DESCRIPTION
When fetching the cookies, they were not used in the subsequent request, and so the request failed. This fix updates the cookies after they are fetched in petcrumb