### PR TITLE
Fix error for endpoints that don't require a crumb

### DIFF
--- a/src/Helpers/CrumbHelper.cs
+++ b/src/Helpers/CrumbHelper.cs
@@ -35,7 +35,7 @@ namespace OoplesFinance.YahooFinanceAPI.Helpers
                 if (loginResponse.Headers.TryGetValues(name: "Set-Cookie", out IEnumerable<string>? setCookie))
                 {
                     cookies = new List<string>(setCookie.Where(c => c.ToLower().IndexOf("domain=.yahoo.com") > 0));                   
-                    var crumbResponse = await client.GetAsync("https://query1.finance.yahoo.com/v1/test/getcrumb");
+                    var crumbResponse = await GetHttpClient().GetAsync("https://query1.finance.yahoo.com/v1/test/getcrumb");
 
                     if (crumbResponse.IsSuccessStatusCode)
                     {

--- a/src/Helpers/CrumbHelper.cs
+++ b/src/Helpers/CrumbHelper.cs
@@ -35,7 +35,7 @@ namespace OoplesFinance.YahooFinanceAPI.Helpers
                 if (loginResponse.Headers.TryGetValues(name: "Set-Cookie", out IEnumerable<string>? setCookie))
                 {
                     cookies = new List<string>(setCookie.Where(c => c.ToLower().IndexOf("domain=.yahoo.com") > 0));                   
-                    var crumbResponse = await GetHttpClient().GetAsync("https://query1.finance.yahoo.com/v1/test/getcrumb");
+                    var crumbResponse = await client.GetAsync("https://query1.finance.yahoo.com/v1/test/getcrumb");
 
                     if (crumbResponse.IsSuccessStatusCode)
                     {

--- a/src/Helpers/CrumbHelper.cs
+++ b/src/Helpers/CrumbHelper.cs
@@ -63,9 +63,14 @@ namespace OoplesFinance.YahooFinanceAPI.Helpers
             return client;
         }
 
-        public static async Task<CrumbHelper> GetInstance()
+        /// <summary>
+        /// Gets CrumbHelper instance, and gets crumb if not already set
+        /// </summary>
+        /// <param name="setCrumb">Set to false for not setting the crumb.</param>
+        /// <returns></returns>
+        public static async Task<CrumbHelper> GetInstance(bool setCrumb = true)
         {
-            if (string.IsNullOrEmpty(Instance.Crumb))
+            if (string.IsNullOrEmpty(Instance.Crumb) && setCrumb)
             {
                 await Instance.SetCrumbAsync();
             }

--- a/src/Helpers/DownloadHelper.cs
+++ b/src/Helpers/DownloadHelper.cs
@@ -90,7 +90,7 @@ internal static class DownloadHelper
             }
             else
             {
-                (await CrumbHelper.GetInstance()).Destroy();
+                (await CrumbHelper.GetInstance(false)).Destroy();
 
                 throw response.StatusCode switch
                 {
@@ -99,7 +99,7 @@ internal static class DownloadHelper
                         "Requested Information Not Available On Yahoo Finance"),
                     HttpStatusCode.Unauthorized => new InvalidOperationException("Yahoo Finance Authentication Error"),
                     HttpStatusCode.Forbidden => new InvalidOperationException("Yahoo Finance Authentication Error"),
-                    _ => new InvalidOperationException("Yahoo Finance Server Error")
+                    _ => new InvalidOperationException("Yahoo Finance Server Error " + response.StatusCode)
                 };
             }
         }

--- a/tests/UnitTests/YahooClientTests.cs
+++ b/tests/UnitTests/YahooClientTests.cs
@@ -2451,7 +2451,7 @@ public sealed class YahooClientTests
         // Act
         Helpers.CrumbHelper.handler = mockHandler.Object;
         using var client = Helpers.CrumbHelper.GetHttpClient();
-        var ex = await Record.ExceptionAsync(Helpers.CrumbHelper.GetInstance);
+        var ex = await Record.ExceptionAsync(()=>Helpers.CrumbHelper.GetInstance());
 
         // Assert
         ex.Should().NotBeNull();


### PR DESCRIPTION
We use an endpoint (https://query2.finance.yahoo.com/v8/finance/chart/) that doesn't require a crumb, but the API still throws an exception when disposing of the crumbhelper. This makes fixes the error message.