### PR TITLE
Dont fetch crumb on destroy

### DIFF
--- a/src/Helpers/CrumbHelper.cs
+++ b/src/Helpers/CrumbHelper.cs
@@ -61,9 +61,9 @@ internal sealed class CrumbHelper
         return client;
     }
 
-    public static async Task<CrumbHelper> GetInstance()
+    public static async Task<CrumbHelper> GetInstance(bool setCrumb = true)
     {
-        if (string.IsNullOrEmpty(Instance.Crumb))
+        if (string.IsNullOrEmpty(Instance.Crumb) && setCrumb)
         {
             await Instance.SetCrumbAsync();
         }

--- a/src/Helpers/DownloadHelper.cs
+++ b/src/Helpers/DownloadHelper.cs
@@ -99,7 +99,7 @@ internal static class DownloadHelper
                         "Requested Information Not Available On Yahoo Finance"),
                     HttpStatusCode.Unauthorized => new InvalidOperationException("Yahoo Finance Authentication Error"),
                     HttpStatusCode.Forbidden => new InvalidOperationException("Yahoo Finance Authentication Error"),
-                    _ => new InvalidOperationException("Yahoo Finance Server Error")
+                    _ => new InvalidOperationException("Yahoo Finance Server Error " + response.StatusCode),
                 };
             }
         }

--- a/src/Helpers/DownloadHelper.cs
+++ b/src/Helpers/DownloadHelper.cs
@@ -90,7 +90,7 @@ internal static class DownloadHelper
             }
             else
             {
-                (await CrumbHelper.GetInstance()).Destroy();
+                (await CrumbHelper.GetInstance(false)).Destroy();
 
                 throw response.StatusCode switch
                 {

--- a/tests/UnitTests/YahooClientTests.cs
+++ b/tests/UnitTests/YahooClientTests.cs
@@ -2451,7 +2451,7 @@ public sealed class YahooClientTests
         // Act
         Helpers.CrumbHelper.handler = mockHandler.Object;
         using var client = Helpers.CrumbHelper.GetHttpClient();
-        var ex = await Record.ExceptionAsync(Helpers.CrumbHelper.GetInstance);
+        var ex = await Record.ExceptionAsync(()=>Helpers.CrumbHelper.GetInstance(true));
 
         // Assert
         ex.Should().NotBeNull();


### PR DESCRIPTION
We fetch an endpoint that doesn't require a crumb (https://query2.finance.yahoo.com/v8/finance/chart/). This fix makes the exception clearer when the request fails